### PR TITLE
Add overwrite=True" to write() commands in cells 8 and 11 in Drizzlepac/align_to_catalogs.ipynb

### DIFF
--- a/notebooks/DrizzlePac/align_to_catalogs/align_to_catalogs.ipynb
+++ b/notebooks/DrizzlePac/align_to_catalogs/align_to_catalogs.ipynb
@@ -223,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sdss_query.write('sdss.cat', format='ascii.commented_header')"
+    "sdss_query.write('sdss.cat', format='ascii.commented_header', overwrite=True)"
    ]
   },
   {
@@ -275,7 +275,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "reduced_query.write('gaia.cat', format='ascii.commented_header')"
+    "reduced_query.write('gaia.cat', format='ascii.commented_header', overwrite=True)"
    ]
   },
   {
@@ -570,5 +570,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
### Relevant Tickets
- [SPB-1298](https://jira.stsci.edu/browse/SPB-1298)
### Summary of changes
- align_to_catalogs.ipynb: added argument "overwrite=True" to write() commands in cells 8 and 11 to resolve "file already exists" error messages