### PR TITLE
CalCOS notebook bugfix

### DIFF
--- a/notebooks/COS/CalCOS/CalCOS.ipynb
+++ b/notebooks/COS/CalCOS/CalCOS.ipynb
@@ -153,25 +153,10 @@
    "source": [
     "# Displays name of current conda environment\n",
     "from os import environ, system\n",
-    "system(\"conda info --envs\")\n",
-    "# print(\"You are using:\", environ[\"CONDA_PREFIX\"])\n",
-    "# try:\n",
-    "#     from os import environ\n",
-    "#     print(\"You are using:\", environ[\"CONDA_DEFAULT_ENV\"])\n",
-    "# except Exception:\n",
-    "#     # Use another method to display the conda environment name if environment variable 'CONDA_DEFAULT_ENV' isn't set.\n",
-    "#     import subprocess\n",
-    "#     process = subprocess.run('conda info --envs |grep \"*\"', shell=True, check=True, stdout=subprocess.PIPE, universal_newlines=True)\n",
-    "#     print(\"Your are using:\", process.stdout.split(\"*\")[0].strip())\n",
-    "\n",
-    "# from os import environ    \n",
-    "# if \"CONDA_DEFAULT_ENV\" in environ:\n",
-    "#     print(\"You are using:\", environ[\"CONDA_DEFAULT_ENV\"])\n",
-    "# else:\n",
-    "#     # Use another method to display the conda environment name if environment variable 'CONDA_DEFAULT_ENV' isn't set.\n",
-    "#     import subprocess\n",
-    "#     process = subprocess.run('conda info --envs |grep \"*\"', shell=True, check=True, stdout=subprocess.PIPE, universal_newlines=True)\n",
-    "#     print(\"Your are using:\", process.stdout.split(\"*\")[0].strip())"
+    "if \"CONDA_DEFAULT_ENV\" in environ:\n",
+    "    print(\"You are using:\", environ[\"CONDA_DEFAULT_ENV\"])\n",
+    "else:\n",
+    "    system(\"conda info --envs\")"
    ]
   },
   {


### PR DESCRIPTION
### Relevant Tickets
- [SPB-1275](https://jira.stsci.edu/browse/SPB-1275)

### Summary of Problem and Implemented Remedy
- Notebook was was failing because environment variable 'CONDA_DEFAULT_ENV' isn't defined.
- Added logic in cell 1 to display the conda environment name using another method if environment variable isn't defined