### PR TITLE
notebook_curators_list.md: added contacts for DrizzlePac

### DIFF
--- a/docs/notebook_curators_list.md
+++ b/docs/notebook_curators_list.md
@@ -7,4 +7,4 @@ NOTE: This information has not been finalized yet.
   - NICMOS: TBD 
   - STIS: [Joleen Carlberg](mailto:jcarlberg@stsci.edu)
   - WFC3: [Sylvia Baggett](mailto:sbaggett@stsci.edu)
-  - DrizzlePac: TBD
+  - DrizzlePac: [Ben Kuhn](mailto:bkuhn@stsci.edu) (primary) and [Fred Dauphin](mailto:fdauphin@stsci.edu) (backup)


### PR DESCRIPTION
### Relevant Ticket
- [SPB-1297](https://jira.stsci.edu/browse/SPB-1297)

### Summary of Changes
- Updated [notebook_curators_list.md](https://github.com/spacetelescope/hst_notebooks/blob/spb-1297/docs/notebook_curators_list.md) with contact info for DrizzlePac notebooks