### PR TITLE
notebook_curators_list.md: added contacts for COS

### DIFF
--- a/docs/notebook_curators_list.md
+++ b/docs/notebook_curators_list.md
@@ -3,7 +3,7 @@ NOTE: This information has not been finalized yet.
 
 - hst_notebooks/
   - ACS: [Norman A Grogin](mailto:nagrogin@stsci.edu)
-  - COS: [Marc Rafelski](mailto:mrafelski@stsci.edu)
+  - COS: [Sierra Gomez](mailto:sigomez@stsci.edu) and [Marc Rafelski](mailto:mrafelski@stsci.edu) 
   - NICMOS: TBD 
   - STIS: [Joleen Carlberg](mailto:jcarlberg@stsci.edu)
   - WFC3: [Sylvia Baggett](mailto:sbaggett@stsci.edu)


### PR DESCRIPTION
Updated notebook_curators_list.md to include @srosagomez as a COS  notebook science content curator.