### PR TITLE
pep8_nb_style_checker.yml: added logic to make code ignore lines starting with exclamation point character

### DIFF
--- a/.github/helpers/pep8_nb_style_checker.py
+++ b/.github/helpers/pep8_nb_style_checker.py
@@ -84,6 +84,7 @@ with open(nb_file) as nf:
                 for ln in cl['source']:
                     # comment out lines with IPython magic commands
                     line = ln if ln[0] != '%' else '# ' + ln
+                    line = ln if ln[0] != '!' else '# ' + ln
 
                     # insert noqa comment if needed (with care for newline char)
                     if (noqa_comment and not line.startswith('#')


### PR DESCRIPTION
- In Jupyter notebook syntax, the exclamation mark (!) allows users to run shell commands from inside a Jupyter Notebook code cell. 
- In regular vanilla python, the starting a line of code with the exclamation mark character will result in a syntax error. 
- pep8_nb_style_checker.py was throwing a "E999 syntax error" message when such a line was detected. 
- This PR fixes that by adding a line of logic so pep8_nb_style_checker.py simply ignores any line of code it encounters that begins with exclamation mark.