### PR TITLE
Debugging and updating the Drizzlepac mask_satellite notebook

### DIFF
--- a/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
+++ b/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
@@ -38,12 +38,11 @@
     "\n",
     "from astropy.io import fits\n",
     "from astroquery.mast import Observations\n",
-    "from astropy.visualization import astropy_mpl_style,LogStretch,ImageNormalize,LinearStretch\n",
+    "from astropy.visualization import astropy_mpl_style, ImageNormalize, LinearStretch\n",
     "from IPython.display import Image\n",
     "import matplotlib.pyplot as plt\n",
     "import pyregion\n",
     "\n",
-    "import acstools\n",
     "from acstools.satdet import detsat, make_mask\n",
     "from acstools.utils_findsat_mrt import update_dq\n",
     "from drizzlepac.astrodrizzle import AstroDrizzle as adriz\n",
@@ -68,10 +67,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Searching for the observsation\n",
+    "# Searching for the observsation\n",
     "results = Observations.query_criteria(obs_id='JC8MB7020', obstype='all')\n",
     "\n",
-    "#Downloading previews and FLC files\n",
+    "# Downloading previews and FLC files\n",
     "jpg_download = Observations.download_products(results['obsid'], mrp_only=False, extension=['jpg'])\n",
     "flc_download = Observations.download_products(results['obsid'], productSubGroupDescription=['FLC'], mrp_only=False)"
    ]
@@ -88,7 +87,7 @@
     "        os.rename(file, os.path.basename(file))\n",
     "        \n",
     "for file in flc_download['Local Path']:\n",
-    "       os.rename(file, os.path.basename(file))\n",
+    "    os.rename(file, os.path.basename(file))\n",
     "        \n",
     "shutil.rmtree('mastDownload')"
    ]
@@ -274,7 +273,7 @@
     "# Making mask out of region file and masking DQ array\n",
     "with fits.open('jc8mb7t5q_flc.fits', mode='update') as hdu:\n",
     "\n",
-    "    dq  = hdu[6].data\n",
+    "    dq = hdu[6].data\n",
     "    mask = reg_file.get_mask(shape=dq.shape)\n",
     "    dq[mask] |= 16384      \n",
     "        \n",

--- a/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
+++ b/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
@@ -44,7 +44,8 @@
     "import pyregion\n",
     "\n",
     "import acstools\n",
-    "from acstools.satdet import detsat, make_mask, update_dq\n",
+    "from acstools.satdet import detsat, make_mask\n",
+    "from acstools.utils_findsat_mrt import update_dq\n",
     "from drizzlepac.astrodrizzle import AstroDrizzle as adriz\n",
     "\n",
     "%matplotlib inline"
@@ -105,7 +106,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Image(filename='jc8mb7020_drc.jpg')"
+    "Image(filename='jc8mb7020_drc.jpg', width=900, height=900)"
    ]
   },
   {
@@ -337,13 +338,21 @@
     "## About this Notebook\n",
     "\n",
     "    Author: R. Avila, STScI ACS Team  \n",
-    "    Updated: December 14, 2018"
+    "    Updated: December 14, 2018\n",
+    "    Updated: June 8, 2023 by A. O'Connor, STScI WFC3 Team "
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -357,7 +366,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.6"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,

--- a/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
+++ b/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
@@ -82,14 +82,18 @@
    "outputs": [],
    "source": [
     "# Cleaning up directories after downloading from MAST\n",
-    "for file in jpg_download['Local Path']:\n",
-    "    if 'drc' in file:\n",
+    "if os.path.exists('mastDownload'):\n",
+    "    for file in jpg_download['Local Path']:\n",
+    "        if 'drc' in file:\n",
+    "            os.rename(file, os.path.basename(file))\n",
+    "\n",
+    "    for file in flc_download['Local Path']:\n",
     "        os.rename(file, os.path.basename(file))\n",
-    "        \n",
-    "for file in flc_download['Local Path']:\n",
-    "    os.rename(file, os.path.basename(file))\n",
-    "        \n",
-    "shutil.rmtree('mastDownload')"
+    "\n",
+    "    shutil.rmtree('mastDownload')\n",
+    "\n",
+    "else:\n",
+    "    pass"
    ]
   },
   {
@@ -338,7 +342,7 @@
     "\n",
     "    Author: R. Avila, STScI ACS Team  \n",
     "    Updated: December 14, 2018\n",
-    "    Updated: June 8, 2023 by A. O'Connor, STScI WFC3 Team "
+    "    Updated: June 12, 2023 by A. O'Connor, STScI WFC3 Team "
    ]
   },
   {

--- a/notebooks/DrizzlePac/mask_satellite/requirements.txt
+++ b/notebooks/DrizzlePac/mask_satellite/requirements.txt
@@ -1,4 +1,4 @@
-acstools==3.5.0
+acstools==3.6.1
 astropy==5.2.1
 astroquery==0.4.6
 drizzlepac==3.5.1


### PR DESCRIPTION
Updating imports from new version of acstools 3.6.1, which includes vital updates to skimage functionality. Also adding a few minor updates to allow images to be displayed correctly. I have updated the requirements.txt to reflect the use of a new acstools version 3.6.1 