### PR TITLE
Update pep8_nb_style_checker.py to ignore PEP8 error F821 (undefined name)

### DIFF
--- a/.github/helpers/nb_flake8_magic.json
+++ b/.github/helpers/nb_flake8_magic.json
@@ -26,7 +26,7 @@
      "source": [
       "# enable PEP8 checker for this notebook\n",
       "%load_ext pycodestyle_magic\n",
-      "%flake8_on --ignore E261,E501,W291,W293\n",
+      "%flake8_on --ignore E261,E501,F821,W291,W293\n",
       "\n",
       "# only allow the checker to throw warnings when there's a violation\n",
       "logging.getLogger('flake8').setLevel('ERROR')\n",


### PR DESCRIPTION
** Relevant Ticket **
- [SPB-1433](https://jira.stsci.edu/browse/SPB-1433)

** Summary of Changes **
- Updated pep8_nb_style_checker.py to ignore PEP8 codes listed in nb_flake8_magic.json
- Added code 'F821' to list of PEP8 codes to ignore.

** Notes **
The following PEP8 errors will be ignored from now on:
- E261 (At least two spaces before inline comment)
- E501 (line too long)
- F821 (undefined name) <- Added to ignore list in this PR
- W291 (Trailing whitespace)
- W293 (Blank line contains whitespace)