### PR TITLE
Relaxed pep8 style checker workflow triggering conditions

### DIFF
--- a/.github/workflows/pep8_nb_style_check.yml
+++ b/.github/workflows/pep8_nb_style_check.yml
@@ -12,11 +12,7 @@ on:
 jobs:
   gather-notebooks:
     # below logic will only allow workflow to trigger under specific conditions
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'Technical Review') &&
-      github.event.pull_request.head.user.login != 'github-actions[bot]' &&
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.state == 'open'
+    if: github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
**Relevant ticket**
- [SPB-1434](https://jira.stsci.edu/browse/SPB-1434)

**Summary of changes**
- Previously, the pep8 style checker workflow would only trigger if a number of conditions were met. This resulted in the workflow only being triggered if a pull request was created with the label "Technical Review" set at the time of creation. If this was not the case and the label was added after the fact, the workflow would not be triggered. 
- This PR removes the restrictions, so the pep8 checker workflow is triggered on PR creation or code changes