### PR TITLE
Update requirements.txt

### DIFF
--- a/notebooks/STIS/drizpac_notebook/requirements.txt
+++ b/notebooks/STIS/drizpac_notebook/requirements.txt
@@ -12,4 +12,4 @@ photutils==1.9.0
 setuptools==52.0.0
 stwcs==1.6.1
 stis_cti @ git+https://github.com/spacetelescope/stis_cti@master
-refstis @ git+https://github.com/spacetelescope/refstis@master
+refstis==0.8.2


### PR DESCRIPTION
The latest `refstis` dependency is now installable via PyPI.