### PR TITLE
Add the instrument lists to the index page

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,3 +1,13 @@
-# STScI Notebook Repository Template
+# STScI Notebook Repository HQ
+This page provides links to notebooks created by various Hubble Space
+Telescope instrument teams and software groups, including:
 
-This is the template that should be used to structure your notebook repository to worth with the STScI notebook CI system.
+[Advanced Camera for Surveys (ACS)](https://www.stsci.edu/hst/instrumentation/acs);
+
+[Cosmic Origins Spectrograph (COS)](https://www.stsci.edu/hst/instrumentation/cos);
+
+[DrizzlePac](https://www.stsci.edu/scientific-community/software/drizzlepac);
+
+[Near Infrared Camera and Multi-Object Spectrometer (NICMOS)](https://www.stsci.edu/hst/instrumentation/legacy/nicmos);
+
+[Space Telescope Imaging Spectrograph (STIS)](https://www.stsci.edu/hst/instrumentation/stis);


### PR DESCRIPTION
This pull request adds instrument information and links to the index page of the hst-notebook.
<img width="1014" alt="image" src="https://github.com/spacetelescope/hst_notebooks/assets/66814693/d6b01db5-e7ad-40dc-860a-e019e0de3ee0">
