### PR TITLE
STIS Coronagraphy: matplotlib deprecation fix

### DIFF
--- a/notebooks/STIS/CoronagraphyViz/STIS_Coronagraphy_Visualization_v2.ipynb
+++ b/notebooks/STIS/CoronagraphyViz/STIS_Coronagraphy_Visualization_v2.ipynb
@@ -360,7 +360,7 @@
     "        elif feature == 'disk':\n",
     "            if ('disk_width' not in kwargs) or ('disk_height' not in kwargs):\n",
     "                raise NameError(\"Disk width and/or height not specified.\")\n",
-    "            el = Ellipse((0, 0), kwargs['disk_width'], kwargs['disk_height'], -orient-45+featurepa, fill=0, fc=None, lw=5, ec='magenta') # angle was incorrectly featurepa+90\n",
+    "            el = Ellipse((0, 0), kwargs['disk_width'], kwargs['disk_height'], angle=-orient-45+featurepa, fill=0, fc=None, lw=5, ec='magenta') # angle was incorrectly featurepa+90\n",
     "            ax_cart.add_patch(el)\n",
     "\n",
     "        else:\n",


### PR DESCRIPTION
STIS Coronagraphy Visualization Tool (v2)
-----------------------------------------

Updated call to `matplotlib.patches.Ellipse` to avoid `MatplotlibDeprecationWarning` with `angle` parameter.

Warning text:
```
/tmp/ipykernel_1237072/490500715.py:229: MatplotlibDeprecationWarning: Passing the angle parameter of __init__() positionally is deprecated since Matplotlib 3.6; the parameter will become keyword-only two minor releases later.
```