### PR TITLE
Enhance navigation clarity on index page

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,6 +1,19 @@
-# STScI HST Notebook Repository HQ
-This page provides links to notebooks created by various Hubble Space
-Telescope instrument teams and software groups, including:
+
+## STScI HST Notebook Repository HQ
+Welcome to the STScI HST Notebook Repository
+This resource provides comprehensive documentation and interactive notebooks created the Hubble Space Telescope instruments teams.
+
+### Interactive Notebooks
+Explore our interactive notebooks for hands-on experience with HST data.
+- [ACS notebooks](./notebooks/ACS/README.md)
+- [COS notebooks](./notebooks/COS/README.md)
+- [DrizzlePac notebooks](./notebooks/DrizzlePac/README.md)
+- [NICMOS notebooks](./notebooks/NICMOS/nicmos_unit_conversion/nicmos_unit_conversion.ipynb)
+- [STIS notebooks](./notebooks/STIS/README.md)
+- [WFC3 notebooks](./notebooks/WFC3/README.md)
+
+### Instrument Documentation
+Here you can find detailed documentation for each instrument used by Hubble Space Telescope.
 
 - [Advanced Camera for Surveys (ACS)](https://www.stsci.edu/hst/instrumentation/acs)
 
@@ -14,3 +27,4 @@ Telescope instrument teams and software groups, including:
 
 - [Wide Field Camera 3 (WFC3)](https://www.stsci.edu/hst/instrumentation/wfc3)
 
+</html>


### PR DESCRIPTION
This PR addresses the issue of navigation clarity on the index page of HST notebooks pages. It revises the introductory text and layout to make it clearer to users where the links lead and how to navigate to the notebook pages.


<img width="1402" alt="image" src="https://github.com/spacetelescope/hst_notebooks/assets/66814693/5fc98b66-8b3b-49ee-bced-9dd934927c75">

