### PR TITLE
Create weekly_broken_link_finder.yml

### DIFF
--- a/.github/workflows/weekly_broken_link_finder.yml
+++ b/.github/workflows/weekly_broken_link_finder.yml
@@ -1,0 +1,8 @@
+name: Weekly broken link check
+on:
+  schedule:
+    - cron: '0 4 * * 0' # 0400 UTC every Sunday
+
+jobs:
+  Scheduled:
+   uses: spacetelescope/notebook-ci-actions/.github/workflows/broken_link_checker.yml@main


### PR DESCRIPTION
**Relevant Pull Requests and Tickets**
- [SPB-1733](https://jira.stsci.edu/browse/SPB-1733)
- [notebook-ci-actions PR #9](https://github.com/spacetelescope/notebook-ci-actions/pull/9)

**Summary**
- This PR adds a caller workflow that will run notebook-ci-actions workflow [broken_link_checker.yml](https://github.com/spacetelescope/notebook-ci-actions/pull/9/commits/d5e677218c4f9063050780b63c1c9b04e292e202) to identify broken links in [https://spacetelescope.github.io/hst_notebooks/](https://spacetelescope.github.io/hst_notebooks/ ) weekly every Sunday at 0400 UTC (2000 ET). 