### PR TITLE
_config.yml: removed four merged notebooks from exclude list.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,15 +48,10 @@ html:
   use_repository_button: true
 # Exclude notebooks that have as-yet unresolved build failures (see tickets SPB-1153SPB-1160, SPB-1168)
 exclude_patterns: [notebooks/DrizzlePac/align_mosaics/align_mosaics.ipynb,
-                   # notebooks/DrizzlePac/sky_matching/sky_matching.ipynb,
                    notebooks/DrizzlePac/use_ds9_regions_in_tweakreg/use_ds9_regions_in_tweakreg.ipynb,
                    notebooks/WFC3/dash/dash.ipynb,
                    notebooks/WFC3/filter_transformations/filter_transformations.ipynb,
                    notebooks/WFC3/flux_conversion_tool/flux_conversion_tool.ipynb,
-                   notebooks/WFC3/image_displayer_analyzer/wfc3_image_displayer_analyzer.ipynb,
-                   notebooks/WFC3/ir_ima_visualization/IR_IMA_Visualization_with_an_Example_of_Time_Variable_Background.ipynb,
                    notebooks/WFC3/ir_scattered_light_calwf3_corrections/Correcting_for_Scattered_Light_in_IR_Exposures_Using_calwf3_to_Mask_Bad_Reads.ipynb,
                    notebooks/WFC3/ir_scattered_light_manual_corrections/Correcting_for_Scattered_Light_in_IR_Exposures_by_Manually_Subtracting_Bad_Reads.ipynb,
-                   notebooks/WFC3/photometry_examples/phot_examples.ipynb,
-                   notebooks/WFC3/tvb_flattenramp/TVB_flattenramp_notebook.ipynb,
                    notebooks/WFC3/zeropoints/zeropoints.ipynb]


### PR DESCRIPTION
**Summary**
The following notebooks were merged into main, and _toc.yml was updated to include them, but they were never removed from the exclude_list in _config.yml:

- wfc3_image_displayer_analyzer.ipynb (PR #105)
- IR_IMA_Visualization_with_an_Example_of_Time_Variable_Background.ipynb (PR #106)
- phot_examples.ipynb (PR #110)
-  TVB_flattenramp_notebook.ipynb (PR #111)

This PR simply removes the above notebooks from the exclude_list and fixes that oversight. 