### PR TITLE
Added CRDS to STIS notebooks requirements

### DIFF
--- a/notebooks/STIS/calstis/calstis_2d_ccd.ipynb
+++ b/notebooks/STIS/calstis/calstis_2d_ccd.ipynb
@@ -485,7 +485,7 @@
    "metadata": {},
    "source": [
     "## 6 CRCORR: Cosmic Ray Correction\n",
-    "The CRCORR step is applied to CCD data only. The CCD exposures are split into multiple associated exposures in order to apply an anti-coincidence technique, and the exposures are specified by the number of iterations NRPTEXP or CRSPLIT parameters. The CRCORR step sums the individual CRSPLIT exposures in an associated dataset, producing a single cosmic ray rejected file. The CRCORR contains the following steps:\n",
+    "The CRCORR step is applied to CCD data only. The CCD exposures are split into multiple associated exposures in order to apply an anti-coincidence technique. The exposures are specified by the number of iterations NRPTEXP or CRSPLIT parameters. The CRCORR step sums the individual CRSPLIT exposures in an associated dataset, producing a single cosmic ray rejected file. The CRCORR contains the following steps:\n",
     " - Forms a stack of images to be combined(the CRSPLIT or NRPTEXP exposures in the input file).\n",
     " - Forms an initial guess image (minimum or median).\n",
     " - Forms a summed CR-rejected image, using the guess image to reject high and low values in the stack, based on sigma and the radius parameter that signifies whether to reject pixels neighboring cosmic ray impacts.\n",

--- a/notebooks/STIS/calstis/requirements.txt
+++ b/notebooks/STIS/calstis/requirements.txt
@@ -2,3 +2,4 @@ astropy==5.2.1
 astroquery==0.4.6
 matplotlib==3.7.0
 stistools==1.4.4
+crds>=11.17

--- a/notebooks/STIS/cross-correlation/cross-correlation.ipynb
+++ b/notebooks/STIS/cross-correlation/cross-correlation.ipynb
@@ -281,7 +281,7 @@
    "metadata": {},
    "source": [
     "### Masking out the Lyman-alpha line\n",
-    "The absorption line at around 1215 Å is from Hydrogen Lyman-alpha, which mostly comes from the atmosphere and so should not shift like the science spectrum. Therefore we need to mask out this region by separating the spectrum into two parts and perform two cross-correlations. There are other airglows lines in the ultraviolet that also does not shift with the science spectrum, including OI line at 1302 Å, OI line at 1305 Å, OI line at 1306 Å. For more information on the Airglow, see: [`AIRGLOW`](https://www.stsci.edu/hst/instrumentation/cos/calibration/airglow)."
+    "The absorption line at around 1215 Å is from Hydrogen Lyman-alpha, which mostly comes from the atmosphere and so should not shift like the science spectrum. Therefore, we need to mask out this region by separating the spectrum into two parts and perform two cross-correlations. There are other airglows lines in the ultraviolet that also does not shift with the science spectrum, including OI line at 1302 Å, OI line at 1305 Å, OI line at 1306 Å. For more information on the Airglow, see: [`AIRGLOW`](https://www.stsci.edu/hst/instrumentation/cos/calibration/airglow)."
    ]
   },
   {

--- a/notebooks/STIS/cross-correlation/requirements.txt
+++ b/notebooks/STIS/cross-correlation/requirements.txt
@@ -4,3 +4,4 @@ matplotlib==3.7.0
 numpy==1.23.4
 scipy==1.10.0
 stistools==1.4.4
+crds>=11.17


### PR DESCRIPTION
Modifying requirements files for STIS `cross-correlation.ipynb` and `calstis_2d_ccd.ipynb` to add the CRDS package.  Hopefully this will allow `calstis` to access reference files when reprocessing data.

These are pre-existing notebooks.