### PR TITLE
Force updates to DrizzlePac notebook github.io webpages Initialization.html, align_multiple_visits.html, and mask_satellite.html

### DIFF
--- a/notebooks/DrizzlePac/Initialization/Initialization.ipynb
+++ b/notebooks/DrizzlePac/Initialization/Initialization.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# DrizzlePac Initialization\n",
     "\n",
-    "<br>This Jupyter notebook discusses the steps necessary to set up your computing environment to use DrizzlePac. This is the first step before using any of the other DrizzlePac tutorials. The code cells in this notebook can be used to partially confirm that your environment is properly configured for DrizzlePac before proceeding to the other tutorials.\n",
+    "<br>This Jupyter notebook discusses the steps necessary to set up your computing environment to use DrizzlePac. This is the first step before using any of the other DrizzlePac tutorials. The code cells in this notebook can be used to partially confirm that your environment is properly configured for DrizzlePac before proceeding to the other tutorials. \n",
     "\n"
    ]
   },
@@ -315,7 +315,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -329,9 +329,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.6"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/DrizzlePac/align_multiple_visits/align_multiple_visits.ipynb
+++ b/notebooks/DrizzlePac/align_multiple_visits/align_multiple_visits.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "This notebook demonstrates how to use `TweakReg` and `AstroDrizzle` tasks to align and combine images. While this example focuses on ACS/WFC data, the procedure can be almost identically applied to WFC3/UVIS images. This notebook is based on [a prior example](http://documents.stsci.edu/hst/HST_overview/documents/DrizzlePac/ch75.html) from the 2012 [DrizzlePac Handbook](http://documents.stsci.edu/hst/HST_overview/documents/DrizzlePac/toc.html), but has been updated for compatibility with the STScI AstroConda software distribution.  There is a good deal of explanatory text in this notebook, and users new to DrizzlePac are encouraged to start with this tutorial. Additional DrizzlePac software documentation is available at [the readthedocs webpage](https://drizzlepac.readthedocs.io).\n",
     "\n",
-    "Before running the notebook, you will need to install the `astroquery` package, which is used to retrieve the data from the MAST archive and the `ccdproc` package which is used to query the image headers. \n",
+    "Before running the notebook, you will need to install the `astroquery` package, which is used to retrieve the data from the MAST archive and the `ccdproc` package which is used to query the image headers.  \n",
     "\n",
     "Summary of steps:\n",
     "\n",
@@ -620,7 +620,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -634,9 +634,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
+++ b/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "Even though Hubble has a small field of view, satellites are commonly captured in images. The cosmic ray rejection algorithm in Astrodrizzle is not well suited to eliminate satellite trails, and the affected adjacent pixels that make up their wings leave ugly blemishes in stacked images. \n",
     "\n",
-    "To fix this problem, the pixels around satellite trails need to be marked as bad in the affected images. There are several ways to do this. The ACS Team has developed multiple algorithms to automatically detect and mask satellite trails. This is the easiest and most convenient way. Masks can also be made manually using DS9 regions. While not as convenient, making masks manually allows you to mask not only satellites, but also any other anomalies with odd shapes (e.g. dragon's breath, glint, blooming). \n",
+    "To fix this problem, the pixels around satellite trails need to be marked as bad in the affected images. There are several ways to do this. The ACS Team has developed multiple algorithms to automatically detect and mask satellite trails. This is the easiest and most convenient way. Masks can also be made manually using DS9 regions. While not as convenient, making masks manually allows you to mask not only satellites, but also any other anomalies with odd shapes (e.g. dragon's breath, glint, blooming).  \n",
     "\n",
     "Both methods are explained below. "
    ]
@@ -203,9 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "w.mask = block_replicate(w.mask, 2, conserve_sum=False)\n",
@@ -343,9 +341,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "source": [
     "## 3. Manual masking of satellites and other anomalies\n",
     "\n",
@@ -482,9 +478,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
**Related Tickets and PRs**
- Ticket [SPB-1810](https://jira.stsci.edu/browse/SPB-1810)
- Ticket [SPB-1804](https://jira.stsci.edu/browse/SPB-1804)
- [PR #184](https://github.com/spacetelescope/hst_notebooks/pull/184)

**Summary**
- For some unknown reason, updates to [Initialization.html](https://spacetelescope.github.io/hst_notebooks/notebooks/DrizzlePac/Initialization/Initialization.html), [align_multiple_visits.html](https://spacetelescope.github.io/hst_notebooks/notebooks/DrizzlePac/align_multiple_visits/align_multiple_visits.html), and [mask_satellite.html](https://spacetelescope.github.io/hst_notebooks/notebooks/DrizzlePac/mask_satellite/mask_satellite.html) fail to post to the github.io page despite the notebook passing all CI checks.
- As shown by [PR #184](https://github.com/spacetelescope/hst_notebooks/pull/184), the solution seems to be to make a super-minor change to the notebooks and PR these changes to force-trigger the HTML generation and posting workflows that automatically kick off when a PR is merged into main.