### PR TITLE
add "dollarmath" to _config.yml to enable math expressions in notebooks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,7 @@ parse:
     # don't forget to list any other extensions you want enabled,
     # including those that are enabled by default! See here: https://jupyterbook.org/en/stable/customize/config.html
     - html_image
+    - dollarmath
 
 launch_buttons:
   thebe                  : true

--- a/notebooks/ACS/acs_cte_forward_model/acs_cte_forward_model_example.ipynb
+++ b/notebooks/ACS/acs_cte_forward_model/acs_cte_forward_model_example.ipynb
@@ -298,7 +298,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, we generate a table of random Gaussian sources of typical brightness for our 47 Tuc field with $\\mathrm{FWHM}\\sim2.5$ pixels. Because $\\mathrm{FWHM} = 2.355\\sigma$, we will generate Gaussian sources with $\\sigma \\sim 1.06$ pixels in both $x$ and $y$."
+    "First, we generate a table of random Gaussian sources of typical brightness for our 47 Tuc field with $\\mathrm{FWHM}\\sim2.5$ pixels. Because $\\mathrm{FWHM} = 2.355\\sigma$, we will generate Gaussian sources with $\\sigma \\sim 1.06$ pixels in both $x$ and $y$. "
    ]
   },
   {
@@ -1365,7 +1365,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**Relevant Tickets**
- [SPB-1856](https://jira.stsci.edu/browse/SPB-1856)

**Summary**
- Previously, mathematical expressions imbedded in dollar signs were not being rendered properly in HTML.
- After some searching a solution was found in [documentation](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#dollar-delimited-math).
- The _config.yml file was updated to fix the issue.  