### PR TITLE
Force HTML update to pages fixed in PRs 202 and 203.

### DIFF
--- a/notebooks/ACS/acs_saturation_trails/acs_saturation_trails.ipynb
+++ b/notebooks/ACS/acs_saturation_trails/acs_saturation_trails.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "However, accurate relative photometry can be obtained as long as a large enough aperture is selected to contain the spilled flux ([ACS ISR 2004-01](http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/acs/documentation/instrument-science-reports-isrs/_documents/isr0401.pdf)). While one could simply use a larger circular aperture, that may introduce error when working with a crowded field (where bright stars are often located).\n",
     "\n",
-    "Here we present a method to identify and perform photometry on saturated sources by defining a custom aperture that is a combination of a standard 0.5\" arcsecond circular aperture and the pixels affected by saturation trails. This method has been tested on ACS/WFC observations of 47 Tuc in the F606W band. The plot below shows the results of using this alternative method to recover flux.\n",
+    "Here we present a method to identify and perform photometry on saturated sources by defining a custom aperture that is a combination of a standard 0.5\" arcsecond circular aperture and the pixels affected by saturation trails. This method has been tested on ACS/WFC observations of 47 Tuc in the F606W band. The plot below shows the results of using this alternative method to recover flux. \n",
     "\n",
     "<img src=photometry_recovery.png width =\"900\" title=\"\" alt=\"\">\n",
     "\n",

--- a/notebooks/ACS/acs_sbc_dark_analysis/acs_sbc_dark_analysis.ipynb
+++ b/notebooks/ACS/acs_sbc_dark_analysis/acs_sbc_dark_analysis.ipynb
@@ -30,7 +30,7 @@
     "\n",
     "This notebook has been prepared as a demo on how to perform aperture photometry in SBC images that contain an elevated dark rate. This problem arises when the detector temperature goes above ~25 ºC. \n",
     "\n",
-    "More information on the dark rate can be found in [ISR ACS 2017-04](http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/acs/documentation/instrument-science-reports-isrs/_documents/isr1704.pdf) (Avila 2017).\n",
+    "More information on the dark rate can be found in [ISR ACS 2017-04](http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/acs/documentation/instrument-science-reports-isrs/_documents/isr1704.pdf) (Avila 2017). \n",
     "\n",
     "### This tutorial will show you how to...\n",
     "\n",
@@ -767,7 +767,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/ACS/acs_subarrays/acs_subarrays.ipynb
+++ b/notebooks/ACS/acs_subarrays/acs_subarrays.ipynb
@@ -34,7 +34,7 @@
     "#### 1. [Post-SM4 Subarray Data](#_postsm4) \n",
     "\n",
     "* Update header keywords.\n",
-    "* Clean Subarray images with the option to correct CTE losses.\n",
+    "* Clean Subarray images with the option to correct CTE losses. \n",
     "* Update WCS solution.\n",
     "\n",
     "#### 2. [Custom Subarray Data](#_custom)\n",
@@ -766,7 +766,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/WFC3/exception_report/wfc3_exception_report.ipynb
+++ b/notebooks/WFC3/exception_report/wfc3_exception_report.ipynb
@@ -21,7 +21,7 @@
     "- Display the data.\n",
     "- Investigate data quality & check for anomalies.\n",
     "- Inspect JIF (jitter/observing log) header keywords for problems.\n",
-    "- Determine if a HOPR is warranted.\n",
+    "- Determine if a HOPR is warranted. \n",
     "\n",
     "## Table of Contents\n",
     "\n",

--- a/notebooks/WFC3/uvis_time_dependent_photometry/uvis_timedep_phot.ipynb
+++ b/notebooks/WFC3/uvis_time_dependent_photometry/uvis_timedep_phot.ipynb
@@ -11,7 +11,7 @@
     "By the end of this tutorial, you will: \n",
     "- Compute aperture photometry on FLC frames acquired at three unique epochs and apply the new time-dependent inverse sensitivity (PHOTFLAM) keywords.\n",
     "- Recompute aperture photometry on modified FLC frames with 'equalized' countrate values.\n",
-    "- Redrizzle the 'equalized' FLC frames and compute aperture photometry on the DRC products.\n",
+    "- Redrizzle the 'equalized' FLC frames and compute aperture photometry on the DRC products. \n",
     "\n",
     "## Table of Contents\n",
     "[Introduction](#intro) <br>\n",
@@ -691,7 +691,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**Relevant PRs**
- PR #202 
- PR #203 

**Summary**
- PRs 202 and 203 fixed broken links in several ACS and WFC3 notebooks. Unfortunately, since only the link URL was updated, and not the human-viewable text, updated HTML was not generated.
- To remedy this, a single space was inserted into all notebooks relevant to the two PRs to manually force an update to the HTML files. 
