### PR TITLE
Update stis_cti links in STIS_DrizzlePac_Tutorial.ipynb

### DIFF
--- a/notebooks/STIS/drizpac_notebook/STIS_DrizzlePac_Tutorial.ipynb
+++ b/notebooks/STIS/drizpac_notebook/STIS_DrizzlePac_Tutorial.ipynb
@@ -30,7 +30,7 @@
     "\n",
     "By the end of this tutorial, you will:\n",
     "- Learn how to download STIS data from [MAST](https://mast.stsci.edu/portal/Mashup/Clients/Mast/Portal.html) using [`astroquery`](https://astroquery.readthedocs.io/en/latest/mast/mast.html).\n",
-    "- CTI correct STIS CCD data with the new pixel-based CTI code [`stis_cti`](https://pythonhosted.org/stis_cti/) (see [webpage](https://www.stsci.edu/hst/instrumentation/stis/data-analysis-and-software-tools/pixel-based-cti) for more details).\n",
+    "- CTI correct STIS CCD data with the new pixel-based CTI code [`stis_cti`](https://stis-cti.readthedocs.io) (see [webpage](https://www.stsci.edu/hst/instrumentation/stis/data-analysis-and-software-tools/pixel-based-cti) for more details).\n",
     "- Align images to sub-pixel accuracy for all three STIS detectors (CCD, NUV MAMA, FUV MAMA) using [`tweakreg`](https://drizzlepac.readthedocs.io/en/latest/tweakreg.html) from [DrizzlePac](https://drizzlepac.readthedocs.io/en/latest/index.html).\n",
     "- Combine images using [`astrodrizzle`](https://drizzlepac.readthedocs.io/en/latest/astrodrizzle.html) from [DrizzlePac](https://drizzlepac.readthedocs.io/en/latest/index.html).\n",
     "\n",
@@ -452,9 +452,9 @@
    "source": [
     "## CTI Correct CCD Images\n",
     "\n",
-    "A pixel-based CTI correction is applied to the STIS CCD data with [`stis_cti`](https://pythonhosted.org/stis_cti/). At present, this code can only be run on post-Servicing Mission 4 (SM4 in 2009) CCD data taken on the default science amplifier D. For all other CCD data, the previous empricial method ([`stistools.ctestis`](https://stistools.readthedocs.io/en/latest/ctestis.html)) can be used.\n",
+    "A pixel-based CTI correction is applied to the STIS CCD data with [`stis_cti`](https://stis-cti.readthedocs.io). At present, this code can only be run on post-Servicing Mission 4 (SM4 in 2009) CCD data taken on the default science amplifier D. For all other CCD data, the previous empricial method ([`stistools.ctestis`](https://stistools.readthedocs.io/en/latest/ctestis.html)) can be used.\n",
     "\n",
-    "First the necessary files are copied over to the CTI correction directory. Then the darks needed to correct the data are determined and downloaded (about ~1.2 GB of data). Then the `stis_cti` code is run, see this [webpage](https://pythonhosted.org/stis_cti/stis_cti.html#stis-cti-stis-cti) for a full description of the parameters. The `num_processes` parameter is the maximum number of parallel processes to use when running `stis_cti`, adjust this as needed for your machine."
+    "First the necessary files are copied over to the CTI correction directory. Then the darks needed to correct the data are determined and downloaded (about ~1.2 GB of data). Then the `stis_cti` code is run, see this [webpage](https://stis-cti.readthedocs.io/en/latest/stis_cti.html#stis-cti-stis-cti) for a full description of the parameters. The `num_processes` parameter is the maximum number of parallel processes to use when running `stis_cti`, adjust this as needed for your machine."
    ]
   },
   {


### PR DESCRIPTION
Updated stis_cti documentation links from pythonhosted.org to readthedocs.io.

The pythonhosted site cannot be updated and will be taken down shortly.