### PR TITLE
Add comment regarding non-standard import of stsynphot

### DIFF
--- a/notebooks/WFC3/zeropoints/zeropoints.ipynb
+++ b/notebooks/WFC3/zeropoints/zeropoints.ipynb
@@ -39,6 +39,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -55,7 +69,9 @@
     "- *matplotlib.pyplot* for plotting data\n",
     "- *astropy* for astronomy related functions\n",
     "\n",
-    "- *synphot* and *stsynphot* for evaluating synthetic photometry"
+    "- *synphot* and *stsynphot* for evaluating synthetic photometry\n",
+    "\n",
+    "We will need to set the `PYSYN_CDBS` environment variable *before* importing stsynphot. We will also create a custom Vega spectrum, as the `stsynphot` will supercede the usual `synphot` functionality regarding the Vega spectrum and would otherwise require a downloaded copy of the spectrum to be provided."
    ]
   },
   {
@@ -120,7 +136,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Rather than downloading the entire calspec database (synphot6.tar.gz), we can point directly to the latest Vega spectrum which is required for computing VEGAMAG."
+    "Now, after having set up `PYSYN_CDBS`, we import stsynphot. A warning regarding the Vega spectrum is expected here."
    ]
   },
   {
@@ -130,6 +146,13 @@
    "outputs": [],
    "source": [
     "import stsynphot as stsyn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Rather than downloading the entire calspec database (synphot6.tar.gz), we can point directly to the latest Vega spectrum which is required for computing VEGAMAG."
    ]
   },
   {
@@ -665,7 +688,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added a comment describing why `stsynphot` cannot be imported directly at the beginning of the notebook, similar to the other WFC3 photometry notebooks.