### PR TITLE
Test refreshing $PATH after installing hstcal

### DIFF
--- a/notebooks/STIS/cross-correlation/cross-correlation.ipynb
+++ b/notebooks/STIS/cross-correlation/cross-correlation.ipynb
@@ -26,7 +26,7 @@
    "metadata": {},
    "source": [
     "## Introduction\n",
-    "If the wavelength calibration fails due to, for example, a bad acquisition, the zero point in the spectral direction of the spectrum might be shifted because of the imprecise target positioning. However, if the target was observed multiple times and at least one has the correct zero point, then this shift can be corrected using cross-correlation. In this notebook, we will go through how to fix the shifted spectrum by cross-correlating it with a calibrated one."
+    "If the wavelength calibration fails due to, for example, a bad acquisition, the zero point in the spectral direction of the spectrum might be shifted because of the imprecise target positioning. However, if the target was observed multiple times and at least one has the correct zero point, then this shift can be corrected using cross-correlation. In this notebook, we will go through how to fix the shifted spectrum by cross-correlating it with a calibrated one. "
    ]
   },
   {

--- a/notebooks/STIS/cross-correlation/pre-requirements.sh
+++ b/notebooks/STIS/cross-correlation/pre-requirements.sh
@@ -1,1 +1,2 @@
 conda install -y -c conda-forge hstcal==2.7.4
+hash -r


### PR DESCRIPTION
Added line to refresh bash cache of binaries in $PATH after conda installation of hstcal.  Minor edit to notebook to force CI reprocessing.

STIS notebook:  cross-correlation.ipynb