### PR TITLE
Update notebooks to test html deployment

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -33,7 +33,7 @@ parts:
       - file: notebooks/DrizzlePac/Initialization/Initialization.ipynb
       - file: notebooks/DrizzlePac/align_to_catalogs/align_to_catalogs.ipynb
 # Notebook excluded from build until build failures are fixed (See SPB-1168)
-#      - file: notebooks/DrizzlePac/align_mosaics/align_mosaics.ipynb
+      - file: notebooks/DrizzlePac/align_mosaics/align_mosaics.ipynb
       - file: notebooks/DrizzlePac/align_multiple_visits/align_multiple_visits.ipynb
       - file: notebooks/DrizzlePac/align_sparse_fields/align_sparse_fields.ipynb
       - file: notebooks/DrizzlePac/drizzle_wfpc2/drizzle_wfpc2.ipynb

--- a/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
+++ b/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
@@ -21,6 +21,7 @@
     "<a id=\"toc\"></a>\n",
     "## Table of Contents\n",
     "[Introduction](#intro_ID) <br>\n",
+    "\n",
     "[Import modules](#import) <br>\n",
     "\n",
     "\n",
@@ -640,7 +641,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true,
     "jupyter": {
      "outputs_hidden": true
     }
@@ -1161,7 +1161,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/DrizzlePac/mask_satellite/requirements.txt
+++ b/notebooks/DrizzlePac/mask_satellite/requirements.txt
@@ -1,4 +1,4 @@
-regions>=0.5
+regions==0.7
 astropy==6.0.0
 astroquery==0.4.6
 crds==11.17.15

--- a/notebooks/DrizzlePac/mask_satellite/requirements.txt
+++ b/notebooks/DrizzlePac/mask_satellite/requirements.txt
@@ -1,4 +1,4 @@
-regions==0.5
+regions>=0.5
 astropy==6.0.0
 astroquery==0.4.6
 crds==11.17.15

--- a/notebooks/DrizzlePac/use_ds9_regions_in_tweakreg/use_ds9_regions_in_tweakreg.ipynb
+++ b/notebooks/DrizzlePac/use_ds9_regions_in_tweakreg/use_ds9_regions_in_tweakreg.ipynb
@@ -17,6 +17,7 @@
     "## Table of Contents\n",
     "\n",
     "[Introduction](#intro)<br>\n",
+    "\n",
     "[Import packages](#imports)<br>\n",
     "\n",
     "[1. Download observations](#download) <br>\n",
@@ -112,7 +113,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -738,7 +738,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
On issue #278, it was reported that 3 notebooks were not displaying the current status of the main on the HTML pages. After investigating, I found:
- align_mosaics is missing on the TOC.
- mask_satillate was failing in CI during the execution step.(Failure was due to `regions` dependency pinning)
- use_ds9_regions_in_tweakreg had no execution or validation errors. This may be due to CI updates and/or a transient issue. 
