### PR TITLE
Test the rebuild of HTML when no nb present

### DIFF
--- a/notebooks/DrizzlePac/README.md
+++ b/notebooks/DrizzlePac/README.md
@@ -52,4 +52,4 @@ pip install notebook
 ```
 
 With the environment activated and additional libraries installed based on the
-individual requirement files, you will be able to complete the notebooks.
+individual requirement files, you will be able to complete the notebooks. 


### PR DESCRIPTION
We experienced issues in the CI when a PR was created with no associated notebooks. As a result, the README failed to reflect the updates from the latest merge due to an execution failure.

