### PR TITLE
Update CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,25 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @eteq
+*    @cshanahan1  @gibsongreen   
+
+# ACS Notebooks
+notebooks/ACS/*/*/*  @alyssaguzman
+
+# COS Notebooks
+notebooks/COS/*/*/*  @mrafelski
+
+# DrizzlePac Notebooks
+notebooks/DrizzlePac/*/*/* @mackjenn @mrevalski @bjkuhn
+
+# NICMOS Notebooks
+notebooks/DrizzlePac/*/*/* @sosey @FDauphin
+
+# WFC3 Notebooks
+notebooks/WFC3/*/*/* @FDauphin
+
+# STIS Notebooks
+notebooks/STIS/*/*/* @Jackie-Brown  @sean-lockwood
 
 # MAST
 notebooks/MAST/*/*/* @ttdu


### PR DESCRIPTION
This updates the CODEOWNERS file to specify two global owners for review of any notebook file and the repo itself, along with folks in INS who are designated as triage/curator for each instrument.


