### PR TITLE
Updated Query Radius

### DIFF
--- a/notebooks/DrizzlePac/align_to_catalogs/align_to_catalogs.ipynb
+++ b/notebooks/DrizzlePac/align_to_catalogs/align_to_catalogs.ipynb
@@ -919,7 +919,7 @@
     "## About this Notebook\n",
     "    \n",
     "    Created: 14 Dec 2018;     V. Bajaj\n",
-    "    Updated: 03 Jul 2024;     M. Revalski, V. Bajaj, & J. Mack\n",
+    "    Updated: 27 May 2025;     M. Revalski, V. Bajaj, & J. Mack\n",
     "\n",
     "**Source:** GitHub [spacetelescope/hst_notebooks](https://github.com/spacetelescope/hst_notebooks)\n",
     "\n",

--- a/notebooks/DrizzlePac/align_to_catalogs/align_to_catalogs.ipynb
+++ b/notebooks/DrizzlePac/align_to_catalogs/align_to_catalogs.ipynb
@@ -308,7 +308,7 @@
    "source": [
     "<a id=\"sdss_query\"></a>\n",
     "### 2.2 SDSS Query\n",
-    "We now give the RA and Dec values to an astropy `SkyCoord` object, which we will pass to the SDSS query.  Additionally, we use an astropy `Quantity` object to create a radius for the SDSS query in physical units.  We set the radius to 5 arcminutes to comfortably cover the area of our images. For reference, the UVIS detector field of view is approximately 2.7'$\\times$2.7' and a y-dither of 82 arcseconds covers a total area on the sky of approximately 2.7'$\\times$4.1'."
+    "We now give the RA and Dec values to an astropy `SkyCoord` object, which we will pass to the SDSS query.  Additionally, we use an astropy `Quantity` object to create a radius for the SDSS query in physical units. For reference, the UVIS detector field of view is approximately 2.7'$\\times$2.7' and a y-dither of 82 arcseconds covers a total area on the sky of approximately 2.7'$\\times$4.1'. For SDSS the maximum search radius is 3 arcminutes, which covers the majority of our field of view in this example. In the Gaia query, we set the radius to 5 arcminutes to fully cover the area of our observations."
    ]
   },
   {
@@ -317,8 +317,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "coord = SkyCoord(ra=RA, dec=Dec, unit=(u.deg, u.deg))\n",
-    "radius = Quantity(3., u.arcmin)"
+    "coord = SkyCoord(ra=RA, dec=Dec, unit=(u.deg, u.deg))"
    ]
   },
   {
@@ -334,6 +333,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "radius = Quantity(3., u.arcmin)\n",
     "sdss_query = SDSS.query_region(coord, radius=radius, spectro=False, fields=['ra', 'dec', 'g'])\n",
     "sdss_query"
    ]
@@ -360,7 +360,7 @@
    "source": [
     "<a id=\"gaia_query\"></a>\n",
     "### 2.3 Gaia Query\n",
-    "Similarly to SDSS, we can query Gaia catalogs for our target via `astroquery.gaia`. This may be preferable in many cases because the spaced-based astrometry from Gaia is generally very accurate and precise. We can use the same `coord` and  `radius` search parameters from our earlier SDSS query."
+    "Similarly to SDSS, we can query Gaia catalogs for our target via `astroquery.gaia`. This may be preferable in many cases because the spaced-based astrometry from Gaia is generally very accurate and precise. We can use the same `coord` search parameters from our earlier SDSS query, along with a slightly larger  `radius` that encompasses the full field of view of these observations."
    ]
   },
   {
@@ -369,6 +369,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "radius = Quantity(5., u.arcmin)\n",
     "gaia_query = Gaia.query_object_async(coordinate=coord, radius=radius)\n",
     "gaia_query"
    ]
@@ -965,7 +966,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/DrizzlePac/align_to_catalogs/requirements.txt
+++ b/notebooks/DrizzlePac/align_to_catalogs/requirements.txt
@@ -1,5 +1,5 @@
 astropy>=6.0.0
-astroquery>=0.4.6
+astroquery==0.4.6 # Currently pinned due to SDSS query issue.
 crds>=11.17.15
 drizzlepac>=3.6.2
 ipython>=8.21.0

--- a/notebooks/DrizzlePac/align_to_catalogs/requirements.txt
+++ b/notebooks/DrizzlePac/align_to_catalogs/requirements.txt
@@ -1,5 +1,5 @@
 astropy>=6.0.0
-astroquery==0.4.6  # SDSS.query_region() method methods changed, causing errors with later releases. The notebook needs to be updated.
+astroquery>=0.4.6
 crds>=11.17.15
 drizzlepac>=3.6.2
 ipython>=8.21.0


### PR DESCRIPTION
The description in this tutorial notebook indicates that a search radius of 5 arcminutes is used for the SDSS and Gaia queries, while in reality a search radius of 3 arcminutes was coded. This is because the SDSS query function has a hard-coded limit of 3 arcminutes. The smaller search radius covers nearly the entire field of view for the data in this tutorial, but we have updated the radius to 5 arcminutes for the Gaia query and clarified the differences and limitation of the SDSS query in the text description.

These minor changes are ready for review by @FDauphin and @cshanahan1 and/or @gibsongreen.