### PR TITLE
Fix html issues in ACS notebooks

### DIFF
--- a/notebooks/ACS/acs_cte_forward_model/acs_cte_forward_model_example.ipynb
+++ b/notebooks/ACS/acs_cte_forward_model/acs_cte_forward_model_example.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "This notebook demonstrates preparing data for input into the ACS/WFC pixel-based CTE forward model and running the model.\n",
     "\n",
-    "### Table of Contents\n",
+    "## Table of Contents\n",
     "\n",
     "[Introduction](#intro_ID) <br>\n",
     "[1. Imports](#imports) <br>\n",

--- a/notebooks/ACS/acs_exception_report/exception_report_checks.ipynb
+++ b/notebooks/ACS/acs_exception_report/exception_report_checks.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "<a id=\"top\"></a>\n",
     "# HST Exception Report - Investigate your ACS Data\n",
-    "***\n",
+    "\n",
     "## Learning Goals\n",
     "In this notebook, we will walk through steps to check your ACS data and observing logs for possible data quality problems indicated by an HST Exception Report and determine if a HOPR or Help Desk ticket needs to be filed.\n",
     "\n",
@@ -650,7 +650,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.10"
+   "version": "3.9.23"
   }
  },
  "nbformat": 4,

--- a/notebooks/ACS/acs_focus_diverse_epsfs/acs_focus_diverse_epsfs.ipynb
+++ b/notebooks/ACS/acs_focus_diverse_epsfs/acs_focus_diverse_epsfs.ipynb
@@ -257,7 +257,7 @@
    "id": "78c17035",
    "metadata": {},
    "source": [
-    "### via *astroquery*"
+    "## via *astroquery*"
    ]
   },
   {
@@ -315,14 +315,6 @@
    "metadata": {},
    "source": [
     "# Further Spatial Interpolations"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9c6a35bc",
-   "metadata": {},
-   "source": [
-    "---"
    ]
   },
   {
@@ -414,7 +406,7 @@
    "id": "041df5ae",
    "metadata": {},
    "source": [
-    "### For more help:\n",
+    "## For more help:\n",
     "\n",
     "More details may be found on the [ACS website](http://www.stsci.edu/hst/instrumentation/acs) and in the [ACS Instrument](https://hst-docs.stsci.edu/display/ACSIHB) and [Data Handbooks](https://hst-docs.stsci.edu/acsdhb).\n",
     "\n",
@@ -438,7 +430,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.9.23"
   }
  },
  "nbformat": 4,

--- a/notebooks/ACS/acs_pixel_area_maps/acs_pixel_area_maps.ipynb
+++ b/notebooks/ACS/acs_pixel_area_maps/acs_pixel_area_maps.ipynb
@@ -9,8 +9,6 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "***\n",
-    "\n",
     "The optical design of ACS introduces larger geometric distortion than in other *HST* instruments. In the event a user wishes to perform photometry on data that have not been processed by AstroDrizzle, a correction must be applied to account for the different sizes of the pixels on the sky across the field of view.\n",
     "\n",
     "A pixel area map (PAM), which is an image where each pixel value describes that pixel's area on the sky relative to the native plate scale, is used for this correction. The distortion corrections applied by both AstroDrizzle and the PAMs include observation-specific corrections (e.g., velocity distortion). For the best results, users are advised to create a PAM for each observation individually.\n",
@@ -34,7 +32,6 @@
    "metadata": {},
    "source": [
     "## Imports\n",
-    "***\n",
     "\n",
     "Here we list the Python packages used in this notebook. Links to the documentation for each module is provided for convenience.\n",
     "\n",
@@ -69,11 +66,10 @@
    "metadata": {},
    "source": [
     "## Download the Data\n",
-    "***\n",
     "\n",
     "Here we download all of the data required for this notebook. This is an important step! Some of the image processing steps require all relevant files to be in the working directory. We recommend working with a brand new directory for every new set of data.\n",
     "\n",
-    "#### [GO Proposal 9438](https://stdatu.stsci.edu/proposal_search.php?mission=hst&id=9438): \"The Origin of the Intergalactic Globular Cluster Population in Abell 1185\"\n",
+    "### [GO Proposal 9438](https://stdatu.stsci.edu/proposal_search.php?mission=hst&id=9438): \"The Origin of the Intergalactic Globular Cluster Population in Abell 1185\"\n",
     "\n",
     "For this example, we will only retreive data associated with the Observation ID **J6ME13QHQ**. Using the python package `astroquery`, we can retreive files from the [MAST](http://archive.stsci.edu) archive.\n",
     "\n",
@@ -121,10 +117,10 @@
    "metadata": {},
    "source": [
     "## File Information\n",
-    "***\n",
+    "\n",
     "The structure of the fits files from ACS may be different depending on what kind of observation was made. For more information, refer to Section 2.2 of the [ACS Data Handbook](http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/acs/documentation/other-documents/_documents/acs_dhb.pdf).\n",
     "\n",
-    "#### FLT Files (WFC-Specific)\n",
+    "### FLT Files (WFC-Specific)\n",
     "\n",
     "| Ext        | Name             | Type         | Contains                                                 |\n",
     "|:----------:|------------------|--------------|:---------------------------------------------------------|\n",
@@ -178,7 +174,6 @@
    "metadata": {},
    "source": [
     "## Construct Pixel Area Map <a id=\"_obtain\"></a>\n",
-    "***\n",
     "\n",
     "Function input for `pamutils.pam_from_file` is (input_file, extension, output_file). To create a PAM for the first science extension (WFC2) of this observation, we need to specify HDU Extension 1."
    ]
@@ -213,7 +208,6 @@
    "metadata": {},
    "source": [
     "## Apply the Pixel Area Map <a id=\"_drkdrizzle\"></a>\n",
-    "***\n",
     "\n",
     "Because the pixel area map is an array of flux corrections based on 2d image distortion, you can multiply it by your data element-by-element to produce the corrected image. Here, we present the results."
    ]
@@ -256,13 +250,6 @@
     "<br></br>\n",
     "<br></br>"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -281,7 +268,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.9.23"
   }
  },
  "nbformat": 4,

--- a/notebooks/ACS/acs_polarization_tools/acs_polarization_tools.ipynb
+++ b/notebooks/ACS/acs_polarization_tools/acs_polarization_tools.ipynb
@@ -9,8 +9,6 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "***\n",
-    "\n",
     "In December 2020, the ACS Team made available a Python module called `polarization_tools` in the `acstools` package to facilitate data analysis of ACS polarization data. This package contains both tables of calibration terms and class methods for polarization calculations. \n",
     "\n",
     "Note that this example does not use imaging data (i.e., FITS files). Where necessary, we will indicate values that come from ACS FITS files.\n",
@@ -35,8 +33,6 @@
    "source": [
     "## Imports\n",
     "\n",
-    "***\n",
-    "\n",
     "Here we list the Python packages used in this notebook. Links to the documentation for each module is provided for convenience.\n",
     "\n",
     "| Package Name     | module           | docs          | used for    |\n",
@@ -59,7 +55,6 @@
    "source": [
     "### Retrieve Polarization Calibration Coefficients<a id=\"_coeffs\"></a>\n",
     "\n",
-    "***\n",
     "\n",
     "The `polarization_tools` module contains all of the necessary calibration terms from the tables in section 5.3 of the ACS Data Handbook (see tables 5.6 and 5.7). These coefficients are stored in YAML files in `acstools` and may be retrieved as `astropy.Table` tables:"
    ]
@@ -109,7 +104,6 @@
    "source": [
     "### Calculate Polarization Properties<a id=\"_properties\"></a>\n",
     "\n",
-    "***\n",
     "\n",
     "The `acstools.polarization_tools.Polarizer` class contains methods for calculating the polarization properties of a source given ACS photometry as input. The inputs may be either in electrons or electrons/second, as long as all three (for each POL0, POL60, and POL120) are consistently in the same units. In addition, the class can accept either a single float value for each photometric measurement or a `numpy` array. This has the advantage that the class can construct Stokes images from the ACS photometry.\n",
     "\n",
@@ -170,13 +164,6 @@
     "<br></br>\n",
     "<br></br>"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -195,7 +182,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.9.23"
   }
  },
  "nbformat": 4,

--- a/notebooks/ACS/acs_reduction/acs_reduction.ipynb
+++ b/notebooks/ACS/acs_reduction/acs_reduction.ipynb
@@ -11,8 +11,6 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "***\n",
-    "\n",
     "This notebook covers the steps necessary to calibrate Advanced Camera for Surveys (ACS) Wide Field Channel (WFC) observations to produce a distortion-corrected image ready for photometry.\n",
     "\n",
     "For most observations, reprocessing the raw files with the calibration pipeline is no longer required as the [MAST](http://archive.stsci.edu) archive is now static and any changes to the pipeline or reference files automatically triggers a reprocessing of the data. However, users may wish to reprocess their data with custom reference files.\n",
@@ -40,7 +38,6 @@
    "metadata": {},
    "source": [
     "## Imports\n",
-    "***\n",
     "\n",
     "Here we list the Python packages used in this notebook. Links to the documentation for each module is provided for convenience.\n",
     "\n",
@@ -80,11 +77,10 @@
    "metadata": {},
    "source": [
     "## Download the Data <a id=\"_download\"></a>\n",
-    "***\n",
     "\n",
     "Here we download all of the data required for this notebook. This is an important step! Some of the image processing steps require all relevant files to be in the working directory. We recommend working with a brand new directory for every new set of data.\n",
     "\n",
-    "#### [GO Proposal 10775](https://stdatu.stsci.edu/proposal_search.php?mission=hst&id=10775): \"An ACS Survey of Galactic Globular Clusters\"\n",
+    "### [GO Proposal 10775](https://stdatu.stsci.edu/proposal_search.php?mission=hst&id=10775): \"An ACS Survey of Galactic Globular Clusters\"\n",
     "\n",
     "For this example, we will only retreive data associated with the Observation ID **J9L960010**. Using the python package `astroquery`, we can access the [MAST](http://archive.stsci.edu) archive. \n",
     "\n",
@@ -153,7 +149,7 @@
    "metadata": {},
    "source": [
     "## File Information\n",
-    "***\n",
+    "\n",
     "The structure of the fits files from ACS may be different depending on what kind of observation was made. For more information, refer to Section 2.2 of the [ACS Data Handbook](http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/acs/documentation/other-documents/_documents/acs_dhb.pdf).\n",
     "\n",
     "### Association Files\n",
@@ -216,11 +212,9 @@
    "source": [
     "## Calibrate Raw Files <a id=\"_calibrate\"></a>\n",
     "\n",
-    "***\n",
-    "\n",
     "Now that we have the `*_raw.fits` files, we can process them with the ACS calibration pipeline `calacs`. \n",
     "\n",
-    "#### Updating Headers for CRDS\n",
+    "### Updating Headers for CRDS\n",
     "\n",
     "By default, the association file will trigger the creation of a drizzled product. In order to avoid this, we will filter the association file to only include table entries with `MEMTYPE` equal to 'EXP-DTH'. This will remove the 'PROD-DTH' entry that prompts AstroDrizzle."
    ]
@@ -412,8 +406,6 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "***\n",
-    "\n",
     "The FLT and FLC images are not yet suitable for photometry. Before performing any analysis on the images, we still need to remove detector artifacts, cosmic rays, and geometric distortion. [AstroDrizzle](http://www.stsci.edu/scientific-community/software/drizzlepac.html) can do all of these steps and produce a single mosaic image that incorporates all of the individual exposures.\n",
     "\n",
     "Users who do not use `astrodrizzle` to correct data for distortion will need to apply a pixel area map to their data to correct for the distorted pixel area projected onto the sky before performing photometry. For those who would like to learn how to create a pixel area map, a Jupyter Notebook on the subject can be found [here](https://github.com/spacetelescope/hst_notebooks/blob/main/notebooks/ACS/acs_pixel_area_maps/acs_pixel_area_maps.ipynb)."
@@ -435,13 +427,6 @@
     "<br></br>\n",
     "<br></br>"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -460,7 +445,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.9.23"
   }
  },
  "nbformat": 4,

--- a/notebooks/ACS/acs_saturation_trails/acs_saturation_trails.ipynb
+++ b/notebooks/ACS/acs_saturation_trails/acs_saturation_trails.ipynb
@@ -9,8 +9,6 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "***\n",
-    "\n",
     "The ACS/WFC CCD becomes saturated around 80000 counts. When this occurs, excess charge from the source spills out lengthwise along the columns of the CCD. This can lead to issues with photometry when using very bright stars, since a significant portion of the star's flux may fall outside of a reasonable extraction radius. \n",
     "\n",
     "However, accurate relative photometry can be obtained as long as a large enough aperture is selected to contain the spilled flux ([ACS ISR 2004-01](http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/acs/documentation/instrument-science-reports-isrs/_documents/isr0401.pdf)). While one could simply use a larger circular aperture, that may introduce error when working with a crowded field (where bright stars are often located).\n",
@@ -59,8 +57,6 @@
    "metadata": {},
    "source": [
     "## Imports\n",
-    "\n",
-    "***\n",
     "\n",
     "Here we list the Python packages used in this notebook. Links to the documentation for each module is provided for convenience.\n",
     "\n",
@@ -131,11 +127,9 @@
    "source": [
     "## Download the Data\n",
     "\n",
-    "***\n",
-    "\n",
     "Here we download all of the data required for this notebook. This is an important step! Some of the image processing steps require all relevant files to be in the working directory. We recommend working with a brand new directory for every new set of data.\n",
     "\n",
-    "#### [GO Proposal 14949](https://stdatu.stsci.edu/proposal_search.php?mission=hst&id=14949): \"ACS External CTE Monitor\"\n",
+    "### [GO Proposal 14949](https://stdatu.stsci.edu/proposal_search.php?mission=hst&id=14949): \"ACS External CTE Monitor\"\n",
     "\n",
     "Using the python package `astroquery`, we can download files from the [MAST](http://archive.stsci.edu) archive.\n",
     "\n",
@@ -246,7 +240,6 @@
    "metadata": {},
    "source": [
     "## 1. Prepare Images <a id=\"_prep\"></a>\n",
-    "***\n",
     "\n",
     "For this notebook, we will need two well-aligned images of the same field on the sky. One image should have a short exposure time (eg. 40 seconds) and the other should have a long exposure time (eg. 400 seconds). Here we assume you already know which images those are, and set those observation files to appropriate variable names."
    ]
@@ -407,7 +400,6 @@
    "metadata": {},
    "source": [
     "## 2. Identify Saturated Stars <a id=\"_identify\"></a>\n",
-    "***\n",
     "\n",
     "Before we begin our modified aperture photometry routine, we should determine whether or not our sources are saturated. We can identify saturated stars by whether or not their saturation trails extend past a typical extraction radius.\n",
     "\n",
@@ -1131,8 +1123,6 @@
    "source": [
     "### References\n",
     "\n",
-    "***\n",
-    "\n",
     "http://iopscience.iop.org/article/10.1086/444553\n",
     "\n"
    ]
@@ -1157,7 +1147,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "acs",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1171,7 +1161,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.9.23"
   }
  },
  "nbformat": 4,

--- a/notebooks/ACS/acs_sbc_dark_analysis/acs_sbc_dark_analysis.ipynb
+++ b/notebooks/ACS/acs_sbc_dark_analysis/acs_sbc_dark_analysis.ipynb
@@ -12,7 +12,6 @@
     "# SBC Dark Analysis\n",
     "\n",
     "## Introduction\n",
-    "***\n",
     "\n",
     "This notebook has been prepared as a demo on how to perform aperture photometry in SBC images that contain an elevated dark rate. This problem arises when the detector temperature goes above ~25 ºC. \n",
     "\n",
@@ -45,7 +44,6 @@
    "metadata": {},
    "source": [
     "## Imports\n",
-    "***\n",
     "\n",
     "Here we list the Python packages used in this notebook. Links to the documentation for each module is provided for convenience.\n",
     "\n",
@@ -69,31 +67,14 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
-  },
-  {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "nbpresent": {
      "id": "6c8b2858-62fe-40bd-a114-8257661e0b0b"
     }
    },
-   "outputs": [
-    {
-     "ename": "ModuleNotFoundError",
-     "evalue": "No module named 'astroquery'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[1], line 8\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mmatplotlib\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mpyplot\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mplt\u001b[39;00m\n\u001b[1;32m      6\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mnumpy\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mnp\u001b[39;00m\n\u001b[0;32m----> 8\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mastroquery\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mmast\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m Observations\n\u001b[1;32m      9\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mdrizzlepac\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mastrodrizzle\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m AstroDrizzle \u001b[38;5;28;01mas\u001b[39;00m adriz\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mastropy\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mio\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m fits\n",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'astroquery'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "import shutil\n",
@@ -124,13 +105,12 @@
    },
    "source": [
     "## Download the Data\n",
-    "***\n",
     "\n",
     "Here we download all of the data required for this notebook. This is an important step! Some of the image processing steps require all relevant files to be in the working directory. We recommend working with a brand new directory for every new set of data. \n",
     "\n",
     "Using the python package `astroquery`, we can retreive files from the [MAST](http://archive.stsci.edu) archive.\n",
     "\n",
-    "#### [GO Proposal 13655](https://stdatu.stsci.edu/proposal_search.php?mission=hst&id=13655): \"How Lyman alpha bites/beats the dust\"\n",
+    "### [GO Proposal 13655](https://stdatu.stsci.edu/proposal_search.php?mission=hst&id=13655): \"How Lyman alpha bites/beats the dust\"\n",
     "\n",
     "First, we will grab the FLT and ASN files from program 13655. For this example, we only want to retreive the files from visit 11 of this program. We will specify program ID 'JCMC' along with observation set ID '11'.\n",
     "\n",
@@ -158,7 +138,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### [GO Proposal 13961](https://stdatu.stsci.edu/proposal_search.php?mission=hst&id=13961): \"SBC Dark Current Measurement\"\n",
+    "### [GO Proposal 13961](https://stdatu.stsci.edu/proposal_search.php?mission=hst&id=13961): \"SBC Dark Current Measurement\"\n",
     "\n",
     "Now we need a set of dark calibration images. You can use any calibration set as long as the dark rate in the image matches that of your science image (discussed later in this notebook). For convenience, here we download the RAW dark frames from one calibration program: GO Proposal 13961."
    ]
@@ -224,7 +204,6 @@
    "source": [
     "## File Information\n",
     "\n",
-    "***\n",
     "\n",
     "The structure of the fits files from ACS may be different depending on what kind of observation was made. For more information, refer to Section 2.2 of the [ACS Data Handbook](http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/acs/documentation/other-documents/_documents/acs_dhb.pdf).\n",
     "\n",
@@ -294,8 +273,6 @@
    "metadata": {},
    "source": [
     "## Identify Affected Observations <a id=\"_identify\"></a>\n",
-    "\n",
-    "***\n",
     "\n",
     "Let's take a look at some information from our science images. We want to find observations with an average temperature greater than 25$^o$C. We can organize the information in a `Table` object from `astropy.table` for convenience. Here, we define a table with column names and respective data types.\n",
     "\n",
@@ -378,8 +355,6 @@
    "source": [
     "## Combine science images<a id=\"_scidrizzle\"></a>\n",
     "\n",
-    "***\n",
-    "\n",
     "Let's make drizzled products for each filter. We do this by using the ASN files for each filter. The ASN files will tell AstroDrizzle which flat images to combine for a given filter.  Steps 1-6 of the drizzling procedure have been turned off since their purpose is to identify and mask cosmic rays, which do not affect SBC images.\n",
     "\n",
     "The drizzle keyword parameters below are the appropriate ones for SBC data. For \"final_scale\" we use the pixel scale of SBC, 0.025 arcseconds."
@@ -430,8 +405,6 @@
    "metadata": {},
    "source": [
     "## Create dark images <a id=\"_drkdrizzle\"></a>\n",
-    "\n",
-    "***\n",
     "\n",
     "We want to use dark frames to make a drizzled product that will be used to approximate the dark rate to be subtracted from the science product. The dark rate above 25C varies. We need to find the dark frame that contains a *dark rate* similar to your affected image. \n",
     "\n",
@@ -632,8 +605,6 @@
    "source": [
     "## Photometry<a id=\"_photometry\"></a>\n",
     "\n",
-    "***\n",
-    "\n",
     "Now we will use the `photutils` package to set up the two apertures. We will use these apertures to measure the flux of different regions in the images.\n",
     "\n",
     "The first aperture is centered on our target at (735, 710), and is shaped as an elliptical to encompass all of the flux from the source. The other aperture will be the same exact shape, but located near the edge of the detector at (200, 200). "
@@ -717,8 +688,6 @@
    "source": [
     "## Final Thoughts\n",
     "\n",
-    "***\n",
-    "\n",
     "1. The difference in flux in the second aperture (the one in the lower left portion of the image) shows that there is a small residual background of ~0.02 cts/sec in the science frame. This could be real background from the sky (and not dark current from the detector that you might want to account for properly in your flux and error budget.\n",
     "\n",
     "2. The dark frame we created does not have the exact same dark count rate as we measured in the science frame. You could try searching for other darks that more closely resemble your science frame. \n",
@@ -746,7 +715,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "sbcdrk",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -760,7 +729,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.9.23"
   }
  },
  "nbformat": 4,

--- a/notebooks/ACS/acs_subarrays/acs_subarrays.ipynb
+++ b/notebooks/ACS/acs_subarrays/acs_subarrays.ipynb
@@ -9,8 +9,6 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "***\n",
-    "\n",
     "Subarray data requires different considerations than working with full frame images. This notebook will guide you through working with standard post-SM4 subarray data and custom subarray data. \n",
     "\n",
     "After Servicing Mission 4 (SM4; May 2009), the installation of the ASIC during the repair of ACS introduced $1/f$ noise in all ACS images. In the calacs pipeline, only full-frame data have this striping removed. To correct subarray data, the alternative acs_destripe_plus pipeline must be used, which will apply all of calibration steps normally performed by calacs in addition to de-striping for subarray data. De-striping is only possible for 2K subarrays after SM4 until Cycle 24, after which a change to the flight software makes all subarrays eligible for de-striping.<!-- </div> -->\n",
@@ -33,8 +31,6 @@
    "metadata": {},
    "source": [
     "## Imports\n",
-    "\n",
-    "***\n",
     "\n",
     "Here we list the Python packages used in this notebook. Links to the documentation for each module is provided for convenience.\n",
     "\n",
@@ -95,11 +91,9 @@
    "source": [
     "## Download the Data\n",
     "\n",
-    "***\n",
-    "\n",
     "Here we download all of the data required for this notebook. This is an important step! Some of the image processing steps require all relevant files to be in the working directory. We recommend working with a brand new directory for every new set of data.\n",
     "\n",
-    "#### [GO Proposal 14511](https://stdatu.stsci.edu/proposal_search.php?mission=hst&id=14511): \"ACS CCD Stability Monitor\"\n",
+    "### [GO Proposal 14511](https://stdatu.stsci.edu/proposal_search.php?mission=hst&id=14511): \"ACS CCD Stability Monitor\"\n",
     "\n",
     "Our data for the first example comes from a routine calibration program of two images using the post-Cycle 24 WFC1A-1K 1024 x 2072 subarray. We will only use the data associated with the observation id `JD5702JWQ`.\n",
     "\n",
@@ -146,7 +140,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### [GO Proposal 10206](https://stdatu.stsci.edu/proposal_search.php?mission=hst&id=10206): \"What drives the outflows in powerful radio galaxies?\"\n",
+    "### [GO Proposal 10206](https://stdatu.stsci.edu/proposal_search.php?mission=hst&id=10206): \"What drives the outflows in powerful radio galaxies?\"\n",
     "\n",
     "For the second example, we will use a ramp filter observation of the galaxy PLS1345+12 (*HST* proposal 10206). The association name is J92SA0010, and we will only use one image in the association: J92SA0W6Q.\n",
     "\n",
@@ -256,9 +250,7 @@
    "source": [
     "## De-striping and CTE Correction of Post-SM4 Subarray Observations<a id=\"_postsm4\"></a>\n",
     "\n",
-    "***\n",
-    "\n",
-    "#### Download Calibration Files: Update Header Keywords\n",
+    "### Download Calibration Files: Update Header Keywords\n",
     "\n",
     "We can call the [Calibration Reference Data System](https://hst-crds.stsci.edu/) (CRDS) to get the associated calibration files for this image.\n",
     "\n",
@@ -346,9 +338,7 @@
    "source": [
     "## Reducing Custom Subarray Data<a id=\"_custom\"></a>\n",
     "\n",
-    "***\n",
-    "\n",
-    "#### Download Calibration Files\n",
+    "### Download Calibration Files\n",
     "\n",
     "Like before, we can use CRDS to get the associated calibration files for this image."
    ]
@@ -368,7 +358,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Access OSCN Table\n",
+    "### Access OSCN Table\n",
     "\n",
     "The name in the header is of the format '<font face='courier'>ref\\\\$oscn_name.fits</font>', therefore we need to split the string on the '$' character."
    ]
@@ -432,7 +422,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Get the Bias Prescan Information\n",
+    "### Get the Bias Prescan Information\n",
     "\n",
     "From the science image PRI and SCI extension headers that we opened earlier, we can get the information about the readout amplifier and dimensions of the image."
    ]
@@ -490,7 +480,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Update OSCNTAB\n",
+    "### Update OSCNTAB\n",
     "\n",
     "Now that we have confirmed that the `OSCNTAB` file does not contain information about our subarray data, we need to add a new row to the table with our definitions. Let's first view the first few rows of `OSCNTAB` to see what our new entry needs to look like."
    ]
@@ -746,7 +736,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.9.23"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR fixes some formatting issues that were causing errors / warnings in the Manual HTML deploy job. Most of these errors had to do with a section heading being followed immediately by a division line. Building the HTML with nbconvert did not raise these errors, however the CI job which uses sphinx + myst-nb considers this formatting choice wrong and raises an error.

Interestingly, and probably why we didn't catch this initially, is that job passes CI. However, the repo is out of sync with the website, so these needed to be fixed.

There are other HST notebooks that need the same fix, which will be done in a follow up since the ticket for this was pointed just to fix ACS notebooks.
