### PR TITLE
fixing drizzlepac align sparse fields

### DIFF
--- a/notebooks/DrizzlePac/align_sparse_fields/align_sparse_fields.ipynb
+++ b/notebooks/DrizzlePac/align_sparse_fields/align_sparse_fields.ipynb
@@ -270,7 +270,7 @@
    "source": [
     "### 1.2 Inspect the Alignment <a id=\"check_wcs\"></a>\n",
     "\n",
-    "Check the active WCS solution in the image header. If the image is aligned to a catalog, list the number of matches and the fit RMS in mas. <br>\n",
+    "Check the active WCS solution in the image header. If the image is aligned to a catalog, list the number of matches and the fit RMS in units of mas. <br>\n",
     "\n",
     "Convert the fit RMS values to pixels for comparison with the alignment results performed later in this notebook."
    ]
@@ -1013,7 +1013,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This notebook has the 'This notebook currently fails to execute, use as reference only' cell applied and I can't see any obvious issues, so I made a small change to see if re-running the CI would fix this. 
