### PR TITLE
Fix broken links

### DIFF
--- a/notebooks/DrizzlePac/align_mosaics/align_mosaics.ipynb
+++ b/notebooks/DrizzlePac/align_mosaics/align_mosaics.ipynb
@@ -76,7 +76,7 @@
     "\n",
     "### Observations <a id=\"obs\"></a>\n",
     "\n",
-    "Mosaics of the Eagle Nebula were acquired by HST GO/DD [program 13926](http://www.stsci.edu/cgi-bin/get-proposal-info?id=13926&observatory=HST) (PI Z. Levay) in September 2014 for HST's 25th <br>\n",
+    "Mosaics of the Eagle Nebula were acquired by HST GO/DD [program 13926](https://www.stsci.edu/hst-program-info/program/?program=13926) (PI Z. Levay) in September 2014 for HST's 25th <br>\n",
     "Annivery. A 2x2 tile mosaic with the IR detector (~4 arcmin across) was observed in the F110W and F160W filters. \n",
     "\n",
     "A slightly larger 2x2 mosaic with the UVIS detector (~5 arcmin across) was observed with the F502N, F657N, and F673N filters.<br>\n",
@@ -804,7 +804,7 @@
     "\n",
     "An error in determining the sky background may in turn impact the cosmic-ray rejection, and if severe enough, the resulting photometry. Additionally, by not properly matching the sky background before combining frames, correlated noise will be added to the final drizzled products when differences in the background levels are significant. Until now, the recommended workaround has been for users to give `AstroDrizzle` an ASCII file containing user-defined background values via the `skyfile` parameter.\n",
     "\n",
-    "AstroDrizzle now features several options for computing the sky. One of these, `skymethod='match`, is useful for “equalizing” the sky background across large mosaics. This method computes differences in sky values using only pixels in common between images. The sky values will then be set relative to the value computed for the input frame with the lowest sky value for which the MDRIZSKY keyword will be set to 0. In this way, the sky background is not removed, but instead equalized before the data are combined. For more details on the sky matching functions used by `AstroDrizzle`, see the [readthedocs](https://drizzlepac.readthedocs.io/en/latest/drizzlepac_api/sky.html) and [skypac](https://stsci-skypac.readthedocs.io/en/latest/skymatch.html) online documentation."
+    "AstroDrizzle now features several options for computing the sky. One of these, `skymethod='match`, is useful for “equalizing” the sky background across large mosaics. This method computes differences in sky values using only pixels in common between images. The sky values will then be set relative to the value computed for the input frame with the lowest sky value for which the MDRIZSKY keyword will be set to 0. In this way, the sky background is not removed, but instead equalized before the data are combined. For more details on the sky matching functions used by `AstroDrizzle`, see the [readthedocs](https://drizzlepac.readthedocs.io/en/latest/drizzlepac_api/sky.html) and [skypac](https://stsci-skypac.readthedocs.io/en/latest/) online documentation."
    ]
   },
   {
@@ -1215,7 +1215,7 @@
     "* [Citing `astroquery`](https://github.com/astropy/astroquery/blob/main/astroquery/CITATION)\n",
     "* [Citing `drizzlepac`](https://zenodo.org/records/3743274)\n",
     "* [Citing `matplotlib`](https://matplotlib.org/stable/users/project/citing.html)\n",
-    "* [Citing `numpy`](https://www.scipy.org/citing.html#numpy)\n",
+    "* [Citing `numpy`](https://numpy.org/citing-numpy/)\n",
     "<hr>\n"
    ]
   },
@@ -1244,7 +1244,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/DrizzlePac/align_multiple_visits/align_multiple_visits.ipynb
+++ b/notebooks/DrizzlePac/align_multiple_visits/align_multiple_visits.ipynb
@@ -61,7 +61,7 @@
     "## Introduction <a id=\"intro\"></a>\n",
     "[Table of Contents](#toc)\n",
     "\n",
-    "This notebook demonstrates how to use `TweakReg` and `AstroDrizzle` tasks to align and combine images. While this example focuses on ACS/WFC data, the procedure can be almost identically applied to WFC3/UVIS images. This notebook is based on [a prior example](http://documents.stsci.edu/hst/HST_overview/documents/DrizzlePac/ch75.html) from the 2012 [DrizzlePac Handbook](http://documents.stsci.edu/hst/HST_overview/documents/DrizzlePac/toc.html), but has been updated for compatibility with the latest STScI software distribution.  \n",
+    "This notebook demonstrates how to use `TweakReg` and `AstroDrizzle` tasks to align and combine images. While this example focuses on ACS/WFC data, the procedure can be almost identically applied to WFC3/UVIS images. This notebook is based on a prior example in Section 7.5 of the [2012 DrizzlePac Handbook](https://www.stsci.edu/files/live/sites/www/files/home/scientific-community/software/drizzlepac/_documents/drizzlepac-handbook-v1.pdf), but has been updated for compatibility with the latest STScI software distribution.  \n",
     "\n",
     "There is a good deal of explanatory text in this notebook, and users new to DrizzlePac are encouraged to start with this tutorial. Additional `DrizzlePac` software documentation is available at the [readthedocs webpage](https://drizzlepac.readthedocs.io).\n",
     "\n",
@@ -146,7 +146,7 @@
     "<hr>\n",
     "\n",
     "\n",
-    "In this example, we align three F606W full-frame 339 second ACS/WFC images of the globular cluster NGC 104 from ACS/CAL Program [10737](http://www.stsci.edu/cgi-bin/get-proposal-info?id=10737&observatory=HST).  These observations were acquired over a 3-month period in separate visits and at different orientations. We will use calibrated, CTE-corrected `*_flc.fits` files. \n",
+    "In this example, we align three F606W full-frame 339 second ACS/WFC images of the globular cluster NGC 104 from ACS/CAL Program [10737](https://www.stsci.edu/hst-program-info/program/?program=10737).  These observations were acquired over a 3-month period in separate visits and at different orientations. We will use calibrated, CTE-corrected `*_flc.fits` files. \n",
     "\n",
     "            j9irw3fwq_flc.fits\n",
     "            j9irw4b1q_flc.fits\n",
@@ -1169,7 +1169,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/DrizzlePac/align_to_catalogs/align_to_catalogs.ipynb
+++ b/notebooks/DrizzlePac/align_to_catalogs/align_to_catalogs.ipynb
@@ -125,7 +125,7 @@
     "[Table of Contents](#toc)\n",
     "\n",
     "For this notebook, we will download WFC3/UVIS images of NGC 6791 from \n",
-    "program [12692](http://www.stsci.edu/cgi-bin/get-proposal-info?id=12692&observatory=HST) \n",
+    "program [12692](https://www.stsci.edu/hst-program-info/program/?program=12692) \n",
     "in the F606W filter acquired in Visit 01. The three FLC images have been processed by the HST WFC3 pipeline (calwf3), which includes bias subtraction, dark current and CTE correction, cosmic-ray rejection, and flat-fielding:\n",
     "\n",
     "            ibwb01xqq_flc.fits\n",
@@ -324,7 +324,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we perform the query via the `SDSS.query_region` method of `astroquery.sdss`. The `spectro=False` keyword argument means we want to exclude spectroscopic objects, as we are looking for objects to match with an image. In the fields parameter, we specify a list of fields we want returned by the query. In this case we only need the position, as well as a *g*-band magnitude if we want to remove very dim and/or bright objects from the catalog, as those are likely measured poorly. Details on selecting objects by magnitude may be found in the ['Gaia_alignment' notebook](https://github.com/spacetelescope/gaia_alignment). Many other fields are available in the SDSS query and are [documented on this webpage](http://cas.sdss.org/dr7/en/help/browser/description.asp?n=PhotoObj&t=V)."
+    "Next, we perform the query via the `SDSS.query_region` method of `astroquery.sdss`. The `spectro=False` keyword argument means we want to exclude spectroscopic objects, as we are looking for objects to match with an image. In the fields parameter, we specify a list of fields we want returned by the query. In this case we only need the position, as well as a *g*-band magnitude if we want to remove very dim and/or bright objects from the catalog, as those are likely measured poorly. Details on selecting objects by magnitude may be found in the ['Gaia_alignment' notebook](https://github.com/spacetelescope/gaia_alignment). Many other fields are available in the `SDSS.query_region` function, which are [documented on this webpage](https://astroquery.readthedocs.io/en/latest/api/astroquery.sdss.SDSSClass.html#astroquery.sdss.SDSSClass.query_region)."
    ]
   },
   {

--- a/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
+++ b/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
@@ -147,7 +147,7 @@
    "source": [
     "### 1.1 Download the ACS data <a id=\"acs_download\"></a>\n",
     "\n",
-    "The ACS/WFC images to be used are the F814W images of visit B7 from GO program [13498](http://www.stsci.edu/cgi-bin/get-proposal-info?id=13498&observatory=HST). These come from the Hubble Frontier Fields program and are images of the the galaxy cluster MACSJ0717.5+3745. \n",
+    "The ACS/WFC images to be used are the F814W images of visit B7 from GO program [13498](https://www.stsci.edu/hst-program-info/program/?program=13498). These come from the Hubble Frontier Fields program and are images of the the galaxy cluster MACSJ0717.5+3745. \n",
     "\n",
     "The four FLC images have been processed by the HST ACS pipeline (calacs), which includes bias subtraction, dark current correction, cte-correction, cosmic-ray rejection, and flatfielding: \n",
     "\n",
@@ -219,7 +219,7 @@
    "source": [
     "### 1.2 Download the WFC3 data <a id=\"wfc3_download\"></a>\n",
     "\n",
-    "The WFC3/UVIS images to be used are F350LP images from visit 11 of  NGC 4051 from GO program [14697](https://www.stsci.edu/cgi-bin/get-proposal-info?id=14697&observatory=HST). \n",
+    "The WFC3/UVIS images to be used are F350LP images from visit 11 of  NGC 4051 from GO program [14697](https://www.stsci.edu/hst-program-info/program/?program=14697). \n",
     "\n",
     "The three FLC images have been processed by the HST WFC3 pipeline (calwf3), which includes bias subtraction, dark current correction, cte-correction, cosmic-ray rejection, and flatfielding. \n",
     "\n",
@@ -1158,7 +1158,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/DrizzlePac/sky_matching/sky_matching.ipynb
+++ b/notebooks/DrizzlePac/sky_matching/sky_matching.ipynb
@@ -133,7 +133,7 @@
     "<br>\n",
     "\n",
     "WFC3/IR observations of the Horsehead Nebula in the F160W filter obtained in HST proposal\n",
-    "program [12812](http://www.stsci.edu/cgi-bin/get-proposal-info?id=12812&observatory=HST)\n",
+    "program [12812](https://www.stsci.edu/hst-program-info/program/?program=12812)\n",
     "will be used for this demonstration. \n",
     "\n",
     "Nine visits were acquired in a 3x3 mosaic pattern on the sky, with two dither positions per visit in two IR filters. [High level science products](https://archive.stsci.edu/prepds/heritage/horsehead/readme_HLSP_v3.txt) for these datasets were delivered to MAST in 2013, and this notebook is based on that user tutorial but has been updated to align these data to Gaia.\n",
@@ -954,7 +954,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.11.7"
   },
   "varInspector": {
    "cols": {

--- a/notebooks/DrizzlePac/use_ds9_regions_in_tweakreg/use_ds9_regions_in_tweakreg.ipynb
+++ b/notebooks/DrizzlePac/use_ds9_regions_in_tweakreg/use_ds9_regions_in_tweakreg.ipynb
@@ -116,7 +116,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example uses observations of 'MACSJ1149.5+2223-HFFPAR' ([proposal ID 13504](http://www.stsci.edu/cgi-bin/get-proposal-info?id=13504&observatory=HST), files `jcdua3f4q_flc.fits` and `jcdua3f8q_flc.fits`). We provide code below to retrieve the ACS/WFC calibrated FLC files. \n",
+    "This example uses observations of 'MACSJ1149.5+2223-HFFPAR' ([proposal ID 13504](https://www.stsci.edu/hst-program-info/program/?program=13504), files `jcdua3f4q_flc.fits` and `jcdua3f8q_flc.fits`). We provide code below to retrieve the ACS/WFC calibrated FLC files. \n",
     "\n",
     "Data are downloaded using the `astroquery` API to access the [MAST](http://archive.stsci.edu/) archive. The `astroquery.mast` [documentation](http://astroquery.readthedocs.io/en/latest/mast/mast.html) has more examples for how to find and download data from MAST.\n",
     "\n",
@@ -743,7 +743,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/DrizzlePac/using_updated_astrometry_solutions/using_updated_astrometry_solutions.ipynb
+++ b/notebooks/DrizzlePac/using_updated_astrometry_solutions/using_updated_astrometry_solutions.ipynb
@@ -144,7 +144,7 @@
     "&nbsp;&nbsp;&nbsp;&nbsp;$\\rightarrow$ type = standard products (CALxxx) or advanced products (HAP-SVM)\n",
     "<hr>\n",
     "\n",
-    "Let's find some example HST data from MAST and download it. The example used here is from visit 14 of program [16801](http://www.stsci.edu/cgi-bin/get-proposal-info?id=16801&observatory=HST). The associations IEPW14030 and IEPW14040 each contain two FLC images in the F336W and F225W filters and a single DRC combined image for each filter.  Here we download the FLC, DRC, and ASN files using `astroquery`.\n",
+    "Let's find some example HST data from MAST and download it. The example used here is from visit 14 of program [16801](https://www.stsci.edu/hst-program-info/program/?program=16801). The associations IEPW14030 and IEPW14040 each contain two FLC images in the F336W and F225W filters and a single DRC combined image for each filter.  Here we download the FLC, DRC, and ASN files using `astroquery`.\n",
     "\n",
     "<div class=\"alert alert-block alert-info\" style=\"color:black\" >  Depending on your connection speed this cell may take a few minutes to execute. </div>"
    ]
@@ -981,7 +981,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi @alyssaguzman and @cshanahan1, this update fixes the broken links found by the weekly CI check:

https://github.com/spacetelescope/hst_notebooks/actions/runs/17888727344/job/50866327417

There are no other changes to the notebooks and this can be merged immediately unless there are concerns.

Have a great day!