### PR TITLE
Fixed Broken Link

### DIFF
--- a/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
+++ b/notebooks/DrizzlePac/mask_satellite/mask_satellite.ipynb
@@ -765,7 +765,7 @@
     "[Table of Contents](#toc)\n",
     "\n",
     "\n",
-    "The WFC3/UVIS images to be used are F350LP images from visit 11 of  NGC 4051 from GO program [14697](https://www.stsci.edu/cgi-bin/get-proposal-info?id=14697&observatory=HST). \n",
+    "The WFC3/UVIS images to be used are F350LP images from visit 11 of  NGC 4051 from GO program [14697](https://www.stsci.edu/hst-program-info/program/?program=14697). \n",
     "\n",
     "Although the both `findsat_mrt` and `satdet` were initially designed for use with ACS/WFC imaging data, they both also work well for WFC3/UVIS data. Thanks for the similar file structure, most calls to these programs are identical to the example above aside from modifying the file names. "
    ]
@@ -1158,7 +1158,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
There was one additional broken link pointing to the deprecated HST program search form, which has now been corrected.