### PR TITLE
fixing broken links in STIS notebooks

### DIFF
--- a/notebooks/STIS/calstis/calstis_2d_ccd.ipynb
+++ b/notebooks/STIS/calstis/calstis_2d_ccd.ipynb
@@ -153,7 +153,7 @@
    "source": [
     "## 1 Control Calstis Steps Through Calibration Switches\n",
     "\n",
-    "As with the other current HST instruments, the specific operations that are performed during the calibration process are controlled by calibration switches, which are stored in the image headers. The switch values are stored in the primary extension of the FITS file. It can be set to `PERFORM`, `OMIT`, or `COMPLETE` using [fits.setval()](https://docs.astropy.org/en/stable/generated/examples/io/modify-fits-header.html).\n",
+    "As with the other current HST instruments, the specific operations that are performed during the calibration process are controlled by calibration switches, which are stored in the image headers. The switch values are stored in the primary extension of the FITS file. It can be set to `PERFORM`, `OMIT`, or `COMPLETE` using [fits.setval()](https://docs.astropy.org/en/latest/io/fits/index.html#convenience-functions).\n",
     "\n",
     "We first turn off all switches in the _raw fits file, and then turn them on one-by-one according to [data flow through calstis](https://hst-docs.stsci.edu/stisdhb/chapter-3-stis-calibration/3-3-data-flow-through-calstis) to demonstrate each calibration steps.\n",
     "\n",

--- a/notebooks/STIS/contrast_sensitivity/STIS_Coronagraphic_Observation_Feasibility.ipynb
+++ b/notebooks/STIS/contrast_sensitivity/STIS_Coronagraphic_Observation_Feasibility.ipynb
@@ -66,7 +66,7 @@
    "id": "02a5f16a",
    "metadata": {},
    "source": [
-    "The purpose of this notebook is to provide a function to assess the direct imaging detectability of point sources and/or disks around stars using STIS coronagraphy. The predicted noise that is estimated for the contrast sensitivity calculation is based on [Debes et al. 2019](https://www.spiedigitallibrary.org/journals/Journal-of-Astronomical-Telescopes-Instruments-and-Systems/volume-5/issue-03/035003/Pushing-the-limits-of-the-coronagraphic-occulters-on-Hubble-Space/10.1117/1.JATIS.5.3.035003.full#_=_), which contains the full explanation of the treatmeant of each of the noise parameters used in this notebook.\n",
+    "The purpose of this notebook is to provide a function to assess the direct imaging detectability of point sources and/or disks around stars using STIS coronagraphy. The predicted noise that is estimated for the contrast sensitivity calculation is based on [Debes et al. 2019](https://arxiv.org/abs/1905.06838), which contains the full explanation of the treatmeant of each of the noise parameters used in this notebook.\n",
     "\n",
     "The function `plot_contrast` is used to produce a plot showing the predicted contrast sensitivty and takes the following keywords:\n",
     "    \n",
@@ -115,7 +115,7 @@
     "In order to read in a custom surface brightness profile for a disk, a .txt file must be provided. In column 1 the user provides the projected separation in arcseconds (\") and column 2 is the contrast ratio between the host star and the disk.\n",
     "    \n",
     "### Some additional notes:\n",
-    "- The contrast sensivity calculation is intended as a prediction on the contrast sensitivity limit and does not fully take into the account post-processing techniques that may be used. In [Debes et al. 2019](https://www.spiedigitallibrary.org/journals/Journal-of-Astronomical-Telescopes-Instruments-and-Systems/volume-5/issue-03/035003/Pushing-the-limits-of-the-coronagraphic-occulters-on-Hubble-Space/10.1117/1.JATIS.5.3.035003.full#_=_) the predicted limit for a given observational set up is compared against several post-processing methods.\n",
+    "- The contrast sensivity calculation is intended as a prediction on the contrast sensitivity limit and does not fully take into the account post-processing techniques that may be used. In [Debes et al. 2019](https://arxiv.org/abs/1905.06838) the predicted limit for a given observational set up is compared against several post-processing methods.\n",
     "- There is an option to plot the azimuthally averaged STIS PSF intensity as provided on the [STIS Instrument Website](https://www.stsci.edu/~STIS/coronagraphic_bars/GO12923raw.dat).\n",
     "- The calculation provided here corresponds to the BAR5, WEDGEA0.6, and WEDGEA1.0 aperture locations."
    ]
@@ -406,7 +406,7 @@
    "id": "c4f18c65",
    "metadata": {},
    "source": [
-    "This notebook has been developed with support from John Debes in reference to [Debes et al. 2019](https://www.spiedigitallibrary.org/journals/Journal-of-Astronomical-Telescopes-Instruments-and-Systems/volume-5/issue-03/035003/Pushing-the-limits-of-the-coronagraphic-occulters-on-Hubble-Space/10.1117/1.JATIS.5.3.035003.full#_=_)."
+    "This notebook has been developed with support from John Debes in reference to [Debes et al. 2019](https://arxiv.org/abs/1905.06838)."
    ]
   },
   {

--- a/notebooks/STIS/custom_ccd_darks/custom_ccd_darks.ipynb
+++ b/notebooks/STIS/custom_ccd_darks/custom_ccd_darks.ipynb
@@ -530,8 +530,10 @@
     "If you use `astropy`, `matplotlib`, `astroquery`, or `numpy` for published research, please cite the\n",
     "authors. Follow these links for more information about citations:\n",
     "\n",
-    "* [Citing `astropy`/`numpy`/`matplotlib`](https://www.scipy.org/citing.html)\n",
+    "* [Citing `matplotlib`](https://matplotlib.org/stable/users/project/citing.html)\n",
+    "* [Citing `numpy`](https://numpy.org/citing-numpy/)\n",
     "* [Citing `astroquery`](https://astroquery.readthedocs.io/en/latest/)\n",
+    "* [Citing `astropy`](https://www.astropy.org/acknowledging.html)\n",
     "\n",
     "<hr>\n",
     "\n",
@@ -542,7 +544,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "stenv_py312",
    "language": "python",
    "name": "python3"
   },
@@ -556,7 +558,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.12.11"
   },
   "toc": {
    "base_numbering": "1",

--- a/notebooks/STIS/drizpac_notebook/STIS_DrizzlePac_Tutorial.ipynb
+++ b/notebooks/STIS/drizpac_notebook/STIS_DrizzlePac_Tutorial.ipynb
@@ -16,7 +16,8 @@
     "toc": true
    },
    "source": [
-    "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n ",
+    "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n",
+    " \n",
     "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Learning-Goals\" data-toc-modified-id=\"Learning-Goals-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Learning Goals</a></span></li><li><span><a href=\"#Introduction\" data-toc-modified-id=\"Introduction-2\"><span class=\"toc-item-num\">2&nbsp;&nbsp;</span>Introduction</a></span><ul class=\"toc-item\"><li><span><a href=\"#STIS-Data-Formats\" data-toc-modified-id=\"STIS-Data-Formats-2.1\"><span class=\"toc-item-num\">2.1&nbsp;&nbsp;</span>STIS Data Formats</a></span></li></ul></li><li><span><a href=\"#Imports\" data-toc-modified-id=\"Imports-3\"><span class=\"toc-item-num\">3&nbsp;&nbsp;</span>Imports</a></span></li><li><span><a href=\"#Set-&amp;-Make-Directories\" data-toc-modified-id=\"Set-&amp;-Make-Directories-4\"><span class=\"toc-item-num\">4&nbsp;&nbsp;</span>Set &amp; Make Directories</a></span></li><li><span><a href=\"#Setting-Up-Reference-File-Directory\" data-toc-modified-id=\"Setting-Up-Reference-File-Directory-5\"><span class=\"toc-item-num\">5&nbsp;&nbsp;</span>Setting Up Reference File Directory</a></span></li><li><span><a href=\"#Downloading-Data\" data-toc-modified-id=\"Downloading-Data-6\"><span class=\"toc-item-num\">6&nbsp;&nbsp;</span>Downloading Data</a></span></li><li><span><a href=\"#Download-Reference-Files\" data-toc-modified-id=\"Download-Reference-Files-7\"><span class=\"toc-item-num\">7&nbsp;&nbsp;</span>Download Reference Files</a></span></li><li><span><a href=\"#CTI-Correct-CCD-Images\" data-toc-modified-id=\"CTI-Correct-CCD-Images-8\"><span class=\"toc-item-num\">8&nbsp;&nbsp;</span>CTI Correct CCD Images</a></span></li><li><span><a href=\"#File-Information\" data-toc-modified-id=\"File-Information-9\"><span class=\"toc-item-num\">9&nbsp;&nbsp;</span>File Information</a></span></li><li><span><a href=\"#Image-Alignment\" data-toc-modified-id=\"Image-Alignment-10\"><span class=\"toc-item-num\">10&nbsp;&nbsp;</span>Image Alignment</a></span><ul class=\"toc-item\"><li><span><a href=\"#Tips-and-Tricks-for-Using-tweakreg\" data-toc-modified-id=\"Tips-and-Tricks-for-Using-tweakreg-10.1\"><span class=\"toc-item-num\">10.1&nbsp;&nbsp;</span>Tips and Tricks for Using <a href=\"https://drizzlepac.readthedocs.io/en/latest/tweakreg.html\" rel=\"nofollow\" target=\"_blank\">tweakreg</a></a></span></li><li><span><a href=\"#Select-Reference-Images\" data-toc-modified-id=\"Select-Reference-Images-10.2\"><span class=\"toc-item-num\">10.2&nbsp;&nbsp;</span>Select Reference Images</a></span></li><li><span><a href=\"#CCD-(CTI-Corrected)-Image-Alignment\" data-toc-modified-id=\"CCD-(CTI-Corrected)-Image-Alignment-10.3\"><span class=\"toc-item-num\">10.3&nbsp;&nbsp;</span>CCD (CTI Corrected) Image Alignment</a></span></li><li><span><a href=\"#NUV-MAMA-Image-Alignment\" data-toc-modified-id=\"NUV-MAMA-Image-Alignment-10.4\"><span class=\"toc-item-num\">10.4&nbsp;&nbsp;</span>NUV MAMA Image Alignment</a></span></li><li><span><a href=\"#FUV-MAMA-Image-Alignment\" data-toc-modified-id=\"FUV-MAMA-Image-Alignment-10.5\"><span class=\"toc-item-num\">10.5&nbsp;&nbsp;</span>FUV MAMA Image Alignment</a></span></li><li><span><a href=\"#Testing-Alignment-Parameters\" data-toc-modified-id=\"Testing-Alignment-Parameters-10.6\"><span class=\"toc-item-num\">10.6&nbsp;&nbsp;</span>Testing Alignment Parameters</a></span></li></ul></li><li><span><a href=\"#Drizzling-Images\" data-toc-modified-id=\"Drizzling-Images-11\"><span class=\"toc-item-num\">11&nbsp;&nbsp;</span>Drizzling Images</a></span><ul class=\"toc-item\"><li><span><a href=\"#CCD-(CTI-Corrected)-Image-Drizzling\" data-toc-modified-id=\"CCD-(CTI-Corrected)-Image-Drizzling-11.1\"><span class=\"toc-item-num\">11.1&nbsp;&nbsp;</span>CCD (CTI Corrected) Image Drizzling</a></span></li><li><span><a href=\"#NUV-MAMA-Image-Drizzling\" data-toc-modified-id=\"NUV-MAMA-Image-Drizzling-11.2\"><span class=\"toc-item-num\">11.2&nbsp;&nbsp;</span>NUV MAMA Image Drizzling</a></span></li><li><span><a href=\"#FUV-MAMA-Image-Drizzling\" data-toc-modified-id=\"FUV-MAMA-Image-Drizzling-11.3\"><span class=\"toc-item-num\">11.3&nbsp;&nbsp;</span>FUV MAMA Image Drizzling</a></span></li></ul></li><li><span><a href=\"#About-this-Notebook\" data-toc-modified-id=\"About-this-Notebook-12\"><span class=\"toc-item-num\">12&nbsp;&nbsp;</span>About this Notebook</a></span></li><li><span><a href=\"#Citations\" data-toc-modified-id=\"Citations-13\"><span class=\"toc-item-num\">13&nbsp;&nbsp;</span>Citations</a></span></li></ul></div>"
    ]
   },
@@ -31,8 +32,8 @@
     "By the end of this tutorial, you will:\n",
     "- Learn how to download STIS data from [MAST](https://mast.stsci.edu/portal/Mashup/Clients/Mast/Portal.html) using [`astroquery`](https://astroquery.readthedocs.io/en/latest/mast/mast.html).\n",
     "- CTI correct STIS CCD data with the new pixel-based CTI code [`stis_cti`](https://stis-cti.readthedocs.io) (see [webpage](https://www.stsci.edu/hst/instrumentation/stis/data-analysis-and-software-tools/pixel-based-cti) for more details).\n",
-    "- Align images to sub-pixel accuracy for all three STIS detectors (CCD, NUV MAMA, FUV MAMA) using [`tweakreg`](https://drizzlepac.readthedocs.io/en/latest/tweakreg.html) from [DrizzlePac](https://drizzlepac.readthedocs.io/en/latest/index.html).\n",
-    "- Combine images using [`astrodrizzle`](https://drizzlepac.readthedocs.io/en/latest/astrodrizzle.html) from [DrizzlePac](https://drizzlepac.readthedocs.io/en/latest/index.html).\n",
+    "- Align images to sub-pixel accuracy for all three STIS detectors (CCD, NUV MAMA, FUV MAMA) using [`tweakreg`](https://drizzlepac.readthedocs.io/en/deployment/tweakreg.html) from [DrizzlePac](https://drizzlepac.readthedocs.io/en/latest/index.html).\n",
+    "- Combine images using [`astrodrizzle`](https://drizzlepac.readthedocs.io/en/latest/drizzlepac_api/astrodrizzle.html) from [DrizzlePac](https://drizzlepac.readthedocs.io/en/latest/index.html).\n",
     "\n",
     "## Introduction\n",
     "\n",
@@ -809,7 +810,7 @@
     "## Image Alignment\n",
     "Use `tweakreg` to align the images from the three STIS detectors to sub-pixel accuracy.\n",
     "\n",
-    "### Tips and Tricks for Using [tweakreg](https://drizzlepac.readthedocs.io/en/latest/tweakreg.html)\n",
+    "### Tips and Tricks for Using [tweakreg](https://drizzlepac.readthedocs.io/en/deployment/tweakreg.html)\n",
     "\n",
     "- For `tweakreg` to work on the already distortion-corrected STIS data, it needs the missing header keyword `IDCSCALE` ('default' plate scale for the detector) as done below.\n",
     "- `tweakreg` can align images to better than 0.1 pixel accuracy but it can vary between ~0.05-0.5 pixels depending on the image/number of sources/relative alignment to the reference image etc.\n",
@@ -818,7 +819,7 @@
     "- Testing of parameters should, to first order, improve the accuracy of alignment (`XRMS/YRMS` parameters). But don't rely on this value alone to verify the quality of fit.\n",
     "- Pixel shifts (`XSH/YSH` parameters) between images can range between 0-30 pixels (maybe up to 50 pixels). Expected shifts can be sanity checked by eye with an image viewer (e.g. DS9). Very large shifts (>100 pixels) likely indicate a false solution.\n",
     "- The number of sources found in images and used for alignment is less important than the quality of the sources used. See the **Testing Alignment Parameters** section below for code to overplot the sources used for alignment on the images.\n",
-    "- Below are common parameters to adjust to align images ([input image params](https://drizzlepac.readthedocs.io/en/latest/imagefindpars.html)/[reference image params](https://drizzlepac.readthedocs.io/en/latest/refimagefindpars.html)), trial and error is best for honing in on a solution:\n",
+    "- Below are common parameters to adjust to align images ([input image params](https://drizzlepac.readthedocs.io/en/deployment/imagefindpars.html)/[reference image params](https://drizzlepac.readthedocs.io/en/deployment/refimagefindpars.html)), trial and error is best for honing in on a solution:\n",
     "    - `threshold`: sigma limit above background for source detection.\n",
     "        - Note that sigma is highly image dependent and can vary widely (e.g. from 0.5 to 200 for the same image and get similar results). It is worth exploring a wide parameter space to find an initial solution.\n",
     "    - `minobj`: Minimum number of objects to be matched between images. \n",
@@ -1196,14 +1197,14 @@
    "source": [
     "## Drizzling Images\n",
     "\n",
-    "Next, the images for each detector are combined using `astrodrizzle`. The high-level concept behind drizzling images is described in detail in [Section 3.2 of the DrizzlePac Handbook](https://hst-docs.stsci.edu/drizzpac/files/60245881/109774911/1/1642098151920/DrizzlePac_Handbook_v2.pdf). \n",
+    "Next, the images for each detector are combined using `astrodrizzle`. The high-level concept behind drizzling images is described in detail in [Section 3.2 of the DrizzlePac Handbook](https://hst-docs.stsci.edu/drizzpac/chapter-3-description-of-the-drizzle-algorithm/3-2-drizzle-concept). \n",
     "\n",
-    "Setting the appropriate `final_scale` and `final_pixfrac` parameters for your images takes some thought and testing to avoid gaps in the data. The figure below shows a basic example of the native pixel scale (red squares), shrink factor `final_pixfrac` (blue squares) and output final pixel scale `final_scale` (grid on right) in a drizzle. For more details on the `astrodrizzle` input parameters, see the the [DrizzlePac code webpages](https://drizzlepac.readthedocs.io/en/latest/astrodrizzle.html).\n",
+    "Setting the appropriate `final_scale` and `final_pixfrac` parameters for your images takes some thought and testing to avoid gaps in the data. The figure below shows a basic example of the native pixel scale (red squares), shrink factor `final_pixfrac` (blue squares) and output final pixel scale `final_scale` (grid on right) in a drizzle. For more details on the `astrodrizzle` input parameters, see the the [DrizzlePac code webpages](https://drizzlepac.readthedocs.io/en/latest/drizzlepac_api/astrodrizzle.html).\n",
     "<img src=\"drizzle.png\" alt=\"Drizzle\" style=\"width: 600px;\"/>\n",
     "\n",
     "`astrodrizzle` can be used to increase the pixel sampling of data if images have dithering and different position angles (PAs). For the STIS data used here, all images are at the same PA and therefore sub-sampling the data is not possible. The example for the STIS data shown below adopts the native pixel scale of each detector as the `final_scale` and no fractional scaling down of each pixel (`final_pixfrac=1.0`) prior to drizzling. Drizzle in this context is a useful tool for creating mosaics of images aligned with `tweakreg`.\n",
     "\n",
-    "To ensure that `astrodrizzle` does not apply additional calibrations to the already calibrated STIS data, Steps 1-6 can be 'switched off' using the appropriate keywords (see [`astrodrizzle` webpage](https://drizzlepac.readthedocs.io/en/latest/astrodrizzle.html) for keyword information). The CCD data are already CR-rejected and the MAMA data don't require this step, therefore many of those first steps (and their associated keywords) are to do with appropriately applying CR-rejection. Therefore the 'minmed' warning is not important for the STIS images.\n",
+    "To ensure that `astrodrizzle` does not apply additional calibrations to the already calibrated STIS data, Steps 1-6 can be 'switched off' using the appropriate keywords (see [`astrodrizzle` webpage](https://drizzlepac.readthedocs.io/en/latest/drizzlepac_api/astrodrizzle.html) for keyword information). The CCD data are already CR-rejected and the MAMA data don't require this step, therefore many of those first steps (and their associated keywords) are to do with appropriately applying CR-rejection. Therefore the 'minmed' warning is not important for the STIS images.\n",
     "\n",
     "Only data in a single filter for each detector are combined in this example: 50CCD (CCD), F25SRF2 (NUV MAMA), 25MAMA (FUV MAMA). STIS data have cleaned edges after the distortion correction is applied in the `calstis` pipeline. These are adaptively cropped out with the `crop_edges` function defined below for each image to avoid gaps in the final mosaics.\n",
     "\n",
@@ -1520,7 +1521,7 @@
     "\n",
     "## Citations\n",
     "\n",
-    "- [The DrizzlePac Handbook](https://www.stsci.edu/files/live/sites/www/files/home/scientific-community/software/drizzlepac/_documents/drizzlepac-handbook.pdf): Hoffmann, S. L., Mack, J., et al., 2021, “The DrizzlePac Handbook”, Version, (Baltimore: STScI).\n",
+    "- [The DrizzlePac Handbook](https://hst-docs.stsci.edu/drizzpac): Hoffmann, S. L., Mack, J., et al., 2021, “The DrizzlePac Handbook”, Version 2.0, (Baltimore: STScI).\n",
     "- [STIS Instrument Handbook](https://hst-docs.stsci.edu/stisihb): Prichard, L., Welty, D. and Jones, A., et al. 2022 \"STIS Instrument Handbook,\" Version 21.0, (Baltimore: STScI).\n",
     "- [STIS Data Handbook](https://hst-docs.stsci.edu/stisdhb): Sohn, S. T., et al., 2019, “STIS Data Handbook”, Version 7.0, (Baltimore: STScI).\n",
     "- See [citing `astropy`](https://www.astropy.org/acknowledging.html)\n",
@@ -1528,14 +1529,6 @@
     "[Top of Page](#top)\n",
     "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6dc668b4",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/STIS/low_count_uncertainties/Low_Count_Uncertainties.ipynb
+++ b/notebooks/STIS/low_count_uncertainties/Low_Count_Uncertainties.ipynb
@@ -817,7 +817,7 @@
    "id": "364e3d0f-4908-4a3b-a61c-3e808bff4c29",
    "metadata": {},
    "source": [
-    "There was recently a bug discovered in the procedure to split STIS TIME-TAG data into sub-exposures. That procedure is carried out with the [`inttag` task in stistools](https://stistools.readthedocs.io/_/downloads/en/doc_updates_rtd/pdf/). `inttag` takes the TIME-TAG table and splits them into sub-exposures with a user-defined duration (*increment* argument) or into a user-defined number of sub-exposures (*rcount* argument). The bug was resulting in errors that were significantly inflated, especially in regions of low flux.\n",
+    "There was recently a bug discovered in the procedure to split STIS TIME-TAG data into sub-exposures. That procedure is carried out with the [`inttag` task in stistools](https://stistools.readthedocs.io/en/latest/inttag.html). `inttag` takes the TIME-TAG table and splits them into sub-exposures with a user-defined duration (*increment* argument) or into a user-defined number of sub-exposures (*rcount* argument). The bug was resulting in errors that were significantly inflated, especially in regions of low flux.\n",
     "\n",
     "Let's download the TIME-TAG file that is associated with the STIS/G140L spectrum of GJ-436 we used above. Previously, we were just using the orbit-long exposure, but let's use the .tag file to split up the file into 3 subexposures using `inttag`.\n",
     "\n",
@@ -1020,7 +1020,7 @@
    "source": [
     "**Recommendation:** In the end, our recommendation is to use the Poisson confidence intervals, but not at the pixel level because measurements along a column are not independent events. You would therefore be justified in calculating the Poisson confidence interval on the summed flux at each wavelength/column.\n",
     "\n",
-    "This bug has been fixed in `stistools.inttag` [here](https://github.com/spacetelescope/stistools/tree/sl_inttag-errors)."
+    "This bug has been fixed in `stistools.inttag` [here](https://github.com/spacetelescope/stistools/releases/tag/1.4.5)."
    ]
   },
   {
@@ -1064,7 +1064,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "stenv_py312",
    "language": "python",
    "name": "python3"
   },
@@ -1078,7 +1078,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION

Fixing broken web links for the following notebooks: calstis_2d_ccd, STIS_Coronagraphic_Observation_Feasibility, custom_ccd_darks, STIS_DrizzlePac_Tutorial, and Low_Count_Uncertainties.