### PR TITLE
updated astroquery version

### DIFF
--- a/notebooks/DrizzlePac/align_to_catalogs/align_to_catalogs.ipynb
+++ b/notebooks/DrizzlePac/align_to_catalogs/align_to_catalogs.ipynb
@@ -342,6 +342,13 @@
    "source": [
     "radius = Quantity(3., u.arcmin)\n",
     "sdss_query = SDSS.query_region(coord, radius=radius, spectro=False, fields=['ra', 'dec', 'g'])\n",
+    "\n",
+    "# Handle the case where 'objID' is included as the first column by some versions of astroquery.\n",
+    "try:\n",
+    "    sdss_query.remove_column('objID')\n",
+    "except KeyError:\n",
+    "    print('The table does not contain an objID column... proceeding.')\n",
+    "    \n",
     "sdss_query"
    ]
   },
@@ -691,6 +698,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.close('all') # Close figures to reduce memory usage."
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -896,7 +912,8 @@
     "ax1.set_xlabel('X (pixels)')\n",
     "ax1.set_ylabel('Y (pixels)')\n",
     "ax2.set_xlabel('X (pixels)')\n",
-    "ax2.set_ylabel('Y (pixels)')"
+    "ax2.set_ylabel('Y (pixels)')\n",
+    "plt.show()"
    ]
   },
   {
@@ -927,6 +944,7 @@
     "    \n",
     "    Created: 14 Dec 2018;     V. Bajaj\n",
     "    Updated: 27 May 2025;     M. Revalski, V. Bajaj, & J. Mack\n",
+    "    Updated: 21 May 2026;     M. Revalski\n",
     "\n",
     "**Source:** GitHub [spacetelescope/hst_notebooks](https://github.com/spacetelescope/hst_notebooks)\n",
     "\n",
@@ -973,7 +991,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/DrizzlePac/align_to_catalogs/requirements.txt
+++ b/notebooks/DrizzlePac/align_to_catalogs/requirements.txt
@@ -1,5 +1,5 @@
 astropy>=6.0.0
-astroquery==0.4.6 # Currently pinned due to SDSS query issue.
+astroquery>=0.4.11
 crds>=11.17.15
 drizzlepac>=3.6.2
 ipython>=8.21.0


### PR DESCRIPTION
Hi @cshanahan1, @gibsongreen, and @annapayne,

This notebook was failing the [weekly CI](https://github.com/spacetelescope/hst_notebooks/actions/runs/25980016873/job/76541130767) due to an unresolved issue with astroquery. The issue was tracked to a problem with the SDSS module, which was returning an additional column during the query, which changed the resulting reference catalog columns expected by tweakreg. The astroquery version has been updated and a check has been added to the query columns.

In addition, a `plt.close('all')` command was added between major notebook sections to reduce memory usage.

We'll be improving this notebook in the coming weeks, so please review this minor fix at your earliest convenience.

Thank you!